### PR TITLE
implemented validation, auth, and activity for assign to feature

### DIFF
--- a/src/app/activity/bounty/Create.ts
+++ b/src/app/activity/bounty/Create.ts
@@ -1,6 +1,6 @@
 import { Bounty } from '../../types/bounty/Bounty';
 import Log, { LogUtils } from '../../utils/Log';
-import { Role, Message, MessageOptions, GuildMember, DMChannel, AwaitMessagesOptions, MessageReaction } from 'discord.js';
+import { Role, Message, MessageOptions, GuildMember, DMChannel, AwaitMessagesOptions, MessageReaction, User } from 'discord.js';
 import DiscordUtils from '../../utils/DiscordUtils';
 import BountyUtils from '../../utils/BountyUtils';
 import MongoDbUtils from '../../utils/MongoDbUtils';
@@ -13,6 +13,7 @@ import { PublishRequest } from '../../requests/PublishRequest';
 import { DeleteRequest } from '../../requests/DeleteRequest';
 import { Activities } from '../../constants/activities';
 import { BountyStatus } from '../../constants/bountyStatus';
+import { BountyCollection } from '../../types/bounty/BountyCollection';
 
 export const createBounty = async (createRequest: CreateRequest): Promise<any> => {
     const guildAndMember = await DiscordUtils.getGuildAndMember(createRequest.guildId, createRequest.userId);
@@ -141,6 +142,11 @@ export const createBounty = async (createRequest: CreateRequest): Promise<any> =
         bountyPreview.embeds[0].fields.push({ name: 'Gated to', value: role.name, inline: false });
     }
 
+    if (newBounty.assign) {
+        const assignedUser: GuildMember = await DiscordUtils.getGuildMemberFromUserId(newBounty.assign, guildId);
+        bountyPreview.embeds[0].fields.push({ name: 'Assigned to', value: assignedUser.user.tag, inline: false });
+    }
+
     const publishOrDeleteMessage = 
         'Thank you! If it looks good, please hit 👍 to publish the bounty.\n' +
         'Once the bounty has been published, others can view and claim the bounty.\n' +
@@ -165,6 +171,10 @@ const createDbHandler = async (
     // TODO: perform copies validation
     const rawCopies = createRequest.copies
     const copies = rawCopies && rawCopies > 0 ? rawCopies : 1;
+
+    if (createRequest.assign) {
+        createRequest.assignedName = (await DiscordUtils.getGuildMemberFromUserId(createRequest.assign, createRequest.guildId)).displayName;
+    }
 
     const listOfPrepBounties: Bounty[] = [];
     for (let i = 0; i < copies; i++) {
@@ -230,6 +240,11 @@ export const generateBountyRecord = (
 
     if (createRequest.gate) {
         bountyRecord.gate = [createRequest.gate]
+    }
+
+    if (createRequest.assign) {
+        bountyRecord.assign = createRequest.assign;
+        bountyRecord.assignName = createRequest.assignedName;
     }
 
     return bountyRecord;

--- a/src/app/activity/bounty/Create.ts
+++ b/src/app/activity/bounty/Create.ts
@@ -244,7 +244,7 @@ export const generateBountyRecord = (
 
     if (createRequest.assign) {
         bountyRecord.assign = createRequest.assign;
-        bountyRecord.assignName = createRequest.assignedName;
+        bountyRecord.assignedName = createRequest.assignedName;
     }
 
     return bountyRecord;

--- a/src/app/activity/bounty/Publish.ts
+++ b/src/app/activity/bounty/Publish.ts
@@ -107,10 +107,15 @@ export const generateEmbedMessage = async (dbBounty: BountyCollection, newStatus
 		},
 	};
 
-	if(dbBounty.gate) {
-			const role = await DiscordUtils.getRoleFromRoleId(dbBounty.gate[0], guildID);
-			messageEmbedOptions.fields.push({ name: 'Gated to', value: role.name, inline: false })
+	if (dbBounty.gate) {
+		const role = await DiscordUtils.getRoleFromRoleId(dbBounty.gate[0], guildID);
+		messageEmbedOptions.fields.push({ name: 'Gated to', value: role.name, inline: false })
     }
+
+	if (dbBounty.assign) {
+		const assignedUser = await DiscordUtils.getGuildMemberFromUserId(dbBounty.assign, guildID);
+		messageEmbedOptions.fields.push({ name: 'Assigned to', value: assignedUser.user.tag, inline: false })
+	}
 
 	return messageEmbedOptions;
 };

--- a/src/app/auth/commandAuth.ts
+++ b/src/app/auth/commandAuth.ts
@@ -104,7 +104,7 @@ const publish = async (request: PublishRequest): Promise<void> => {
         throw new AuthorizationError(
             `Thank you for giving bounty commands a try!\n` +
             `It looks like you don't have permission to ${request.activity} this bounty.\n` +
-            `The creator of this bounty gated it to specific role holders. Check the "gated to" value of the bounty to see which role you would need to claim it.`
+            `The creator of this bounty gated it to specific role holders. Check the "assigned to" value of the bounty to see which role you would need to claim it.`
         )
     }
  }

--- a/src/app/auth/commandAuth.ts
+++ b/src/app/auth/commandAuth.ts
@@ -99,6 +99,14 @@ const publish = async (request: PublishRequest): Promise<void> => {
             `The creator of this bounty gated it to specific role holders. Check the "gated to" value of the bounty to see which role you would need to claim it.`
         );
     }
+
+    if (dbBountyResult.assign && (request.userId !== dbBountyResult.assign)) {
+        throw new AuthorizationError(
+            `Thank you for giving bounty commands a try!\n` +
+            `It looks like you don't have permission to ${request.activity} this bounty.\n` +
+            `The creator of this bounty gated it to specific role holders. Check the "gated to" value of the bounty to see which role you would need to claim it.`
+        )
+    }
  }
 
 const submit = async (request: SubmitRequest): Promise<void> => {

--- a/src/app/commands/bounty/Bounty.ts
+++ b/src/app/commands/bounty/Bounty.ts
@@ -64,7 +64,7 @@ export default class Bounty extends SlashCommand {
                         {
                             name: 'assign',
                             type: CommandOptionType.USER,
-                            description: 'Select a user thaty will have permissions to claim this bounty',
+                            description: 'Select a user that will have permissions to claim this bounty',
                             required: false,
                         }
                     ],

--- a/src/app/commands/bounty/Bounty.ts
+++ b/src/app/commands/bounty/Bounty.ts
@@ -61,6 +61,12 @@ export default class Bounty extends SlashCommand {
                             description: 'Select a role that will have permissions to claim this bounty',
                             required: false,
                         },
+                        {
+                            name: 'assign',
+                            type: CommandOptionType.USER,
+                            description: 'Select a user thaty will have permissions to claim this bounty',
+                            required: false,
+                        }
                     ],
                 },
                 {

--- a/src/app/requests/CreateRequest.ts
+++ b/src/app/requests/CreateRequest.ts
@@ -10,6 +10,8 @@ export class CreateRequest extends Request {
     reward: string;
     copies: number;
     gate: string;
+    assign: string;
+    assignedName: string;
 
     // TODO: remove
     commandContext: CommandContext;
@@ -29,6 +31,7 @@ export class CreateRequest extends Request {
             this.reward = commandContext.options.create['reward'];
             this.copies = commandContext.options.create['copies'];
             this.gate = commandContext.options.create['gate'];
+            this.assign = commandContext.options.create['assign']
 
             // TODO: remove
             this.commandContext = commandContext;

--- a/src/app/types/bounty/Bounty.ts
+++ b/src/app/types/bounty/Bounty.ts
@@ -20,7 +20,7 @@ export interface Bounty {
 	customer_id: string,
 	gate?: string[],
 	assign?: string,
-	assignName?: string
+	assignedName?: string
 }
 
 export type UserObject = {

--- a/src/app/types/bounty/Bounty.ts
+++ b/src/app/types/bounty/Bounty.ts
@@ -19,6 +19,8 @@ export interface Bounty {
 	customerId: string,
 	customer_id: string,
 	gate?: string[],
+	assign?: string,
+	assignName?: string
 }
 
 export type UserObject = {

--- a/src/app/types/bounty/BountyCollection.ts
+++ b/src/app/types/bounty/BountyCollection.ts
@@ -18,6 +18,7 @@ export interface BountyCollection extends Collection {
 	discordMessageId: string,
 	customerId: string,
 	gate: string[],
+	assign: string
 }
 
 export type UserObject = {

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -93,6 +93,16 @@ const BountyUtils = {
         }
     },
 
+    async validateAssign(assign: string, guildId: string): Promise<void> {
+        try {
+            await DiscordUtils.getGuildMemberFromUserId(assign, guildId);
+        }
+        catch (e) {
+            Log.info(`User ${assign} is not a user or was unable to be fetched`);
+            throw new ValidationError('Please gate this bounty to a user in this server.');
+        }
+    },
+
     threeMonthsFromNow(): Date {
         let ts: number = Date.now();
         const date: Date = new Date(ts);

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -99,7 +99,7 @@ const BountyUtils = {
         }
         catch (e) {
             Log.info(`User ${assign} is not a user or was unable to be fetched`);
-            throw new ValidationError('Please gate this bounty to a user in this server.');
+            throw new ValidationError('Please assign this bounty to a user in this server.');
         }
     },
 

--- a/src/app/validation/commandValidation.ts
+++ b/src/app/validation/commandValidation.ts
@@ -70,8 +70,19 @@ const create = async (request: CreateRequest): Promise<void> => {
         );
     }
 
+    if (request.gate && request.assign) {
+        throw new ValidationError(
+            `Thank you for giving bounties a try!\n` +
+            `Please select either assign-to or gate, but not both.`
+        );
+    }
+
     if (request.gate) {
         await BountyUtils.validateGate(request.gate, request.guildId);
+    }
+
+    if (request.assign) {
+        await BountyUtils.validateAssign(request.assign, request.guildId)
     }
 }
 


### PR DESCRIPTION
Squeezing in assign to the production release of the bot rewrite. 

With `assign`, a bounty can be assigned to a specific user that is a member of the server that the bounty was created in. `assign` is an option in the subcommand menu. Only the user specified by `assign` can claim the bounty. 


Testing:
Tested between two users (my behold and phi discord accounts) in BBBS. 