### PR TITLE
feature/guild-roles: implemented publishing of customer roles to cust…

### DIFF
--- a/src/app/activity/roles/CustomerRoles.ts
+++ b/src/app/activity/roles/CustomerRoles.ts
@@ -32,7 +32,7 @@ export const upsertCustomerRoles = async (request: UpsertCustomerRolesRequest): 
 
 const dbHandler = async (request: UpsertCustomerRolesRequest, rolesMap: Map<string, string>): Promise<void> => {
     const db: Db = await MongoDbUtils.connect('bountyboard');
-	const customerRolesCollection = db.collection('customer.roles');
+    const customerRolesCollection = db.collection('customer.roles');
 
 	const dbCustomerRolesResult: CustomerRolesCollection = await customerRolesCollection.findOne({
 		customerId: request.customerId,
@@ -40,14 +40,15 @@ const dbHandler = async (request: UpsertCustomerRolesRequest, rolesMap: Map<stri
 
     if (!dbCustomerRolesResult) {
         await customerRolesCollection.insertOne({
-            customerId: request.customerId
+            customerId: request.customerId,
+            customer_id: request.customerId,
         })
     }
 
 	const writeResult: UpdateWriteOpResult = await customerRolesCollection.updateOne(dbCustomerRolesResult, {
 		$set: {
 			roles: {
-                rolesMap: rolesMap
+                rolesMap: rolesMap,
 			},
 		},
 	});

--- a/src/app/activity/roles/CustomerRoles.ts
+++ b/src/app/activity/roles/CustomerRoles.ts
@@ -1,0 +1,59 @@
+import { Snowflake } from "discord-api-types";
+import { Collection, Role } from "discord.js";
+import { Db, UpdateWriteOpResult } from "mongodb";
+import ValidationError from "../../errors/ValidationError";
+import { UpsertCustomerRolesRequest } from "../../requests/UpsertCustomerRolesRequest";
+import { CustomerRolesCollection } from "../../types/roles/CustomerRolesCollection";
+import DiscordUtils from "../../utils/DiscordUtils";
+import Log from "../../utils/Log";
+import MongoDbUtils from "../../utils/MongoDbUtils";
+
+export const upsertCustomerRoles = async (request: UpsertCustomerRolesRequest): Promise<any> => {
+    Log.info(`Upserting Customer Role record for ${request.customerId}: ${request.customerName}`);
+    // check customer availability
+    if (!(await DiscordUtils.verifyOnlineFromGuildId(request.customerId))) {
+        throw new ValidationError('Requested guild not online');
+    }
+    
+    // get all roles for a guild
+    const updatedRoles: Collection<Snowflake, Role> = await DiscordUtils.getRolesFromGuildId(request.customerId);
+
+    // reduce to necessary data
+    const rolesMap = new Map<string, string>();
+    for (const [snowflake, role] of updatedRoles) {
+        rolesMap.set(snowflake, role.name);
+    }
+
+    // check if record exists in Db, if not create
+    // store in Db, overwriting previous record
+    await dbHandler(request, rolesMap);
+}
+
+
+const dbHandler = async (request: UpsertCustomerRolesRequest, rolesMap: Map<string, string>): Promise<void> => {
+    const db: Db = await MongoDbUtils.connect('bountyboard');
+	const customerRolesCollection = db.collection('customer.roles');
+
+	const dbCustomerRolesResult: CustomerRolesCollection = await customerRolesCollection.findOne({
+		customerId: request.customerId,
+	});
+
+    if (!dbCustomerRolesResult) {
+        await customerRolesCollection.insertOne({
+            customerId: request.customerId
+        })
+    }
+
+	const writeResult: UpdateWriteOpResult = await customerRolesCollection.updateOne(dbCustomerRolesResult, {
+		$set: {
+			roles: {
+                rolesMap: rolesMap
+			},
+		},
+	});
+
+    if (writeResult.result.ok !== 1) {
+        Log.error(`Write result did not execute correctly`);
+        throw new Error(`Write to database for customer.roles ${request.customerId}: ${request.customerName} failed`);
+    }
+}

--- a/src/app/events/README.md
+++ b/src/app/events/README.md
@@ -1,0 +1,33 @@
+# Events
+
+This directory contains event handlers for Discord events. Files in this folder will automatically 
+be registered to listen to the Discord event specified by `name`.
+
+A full list of available Discord events can be found on the
+[discord.js documentation](https://discord.js.org/#/docs/main/stable/class/Client).
+
+Evant handlers are structured as follows:
+```typescript
+export default class implements DiscordEvent {
+    /*
+     * Name of the Discord event to handle.
+     */
+    name = 'guildMemberAdd';
+
+    /*
+     * Optional field. Indicates if this is a one time listener. If true, event
+     * will be registered with `client.once` instead of `client.on`
+     */
+    once = true;
+
+    /* 
+     * Function that is called when event is emitted, Different events pass in a 
+     * varying number of arguments. See discord.js documentation for arguments 
+     * returned by emitted events. Client can be omitted as a function parameter 
+     * if it is not used. 
+     */
+    async execute(...args) { 
+        // Code to handle event
+    };
+}
+```

--- a/src/app/events/RoleCreate.ts
+++ b/src/app/events/RoleCreate.ts
@@ -1,0 +1,26 @@
+import { Role } from "discord.js";
+import { DiscordEvent } from "../types/discord/DiscordEvent";
+import { upsertCustomerRoles } from "../activity/roles/CustomerRoles";
+import { UpsertCustomerRolesRequest } from "../requests/UpsertCustomerRolesRequest";
+import { LogUtils } from "../utils/Log";
+
+export default class implements DiscordEvent {
+    name = 'roleCreate';
+    once = false;
+
+    async execute(role: Role): Promise<any> {
+        await this.roleCreateHandler(role);
+    }
+
+    async roleCreateHandler(role: Role) {
+        const request = await UpsertCustomerRolesRequest.build(role);
+
+        try {
+            await upsertCustomerRoles(request)
+        } catch (e) {
+            LogUtils.logError('Updating Customer Roles failed', e);
+        }
+    }
+    
+
+}

--- a/src/app/events/RoleCreate.ts
+++ b/src/app/events/RoleCreate.ts
@@ -8,7 +8,7 @@ export default class implements DiscordEvent {
     name = 'roleCreate';
     once = false;
 
-    async execute(role: Role): Promise<any> {
+    async execute(role: Role): Promise<void> {
         await this.roleCreateHandler(role);
     }
 

--- a/src/app/events/RoleDelete.ts
+++ b/src/app/events/RoleDelete.ts
@@ -1,0 +1,25 @@
+import { Role } from "discord.js";
+import { upsertCustomerRoles } from "../activity/roles/CustomerRoles";
+import { UpsertCustomerRolesRequest } from "../requests/UpsertCustomerRolesRequest";
+import { DiscordEvent } from "../types/discord/DiscordEvent";
+import { LogUtils } from "../utils/Log";
+
+export default class implements DiscordEvent {
+    name = 'roleDelete';
+    once = false;
+
+    async execute(role: Role): Promise<any> {
+        await this.roleDeleteHandler(role);
+    }
+
+    async roleDeleteHandler(role: Role) {
+        const request = await UpsertCustomerRolesRequest.build(role);
+
+        try {
+            await upsertCustomerRoles(request)
+        } catch (e) {
+            LogUtils.logError('Updating Customer Roles failed', e);
+        }
+    }
+
+}

--- a/src/app/events/RoleDelete.ts
+++ b/src/app/events/RoleDelete.ts
@@ -8,7 +8,7 @@ export default class implements DiscordEvent {
     name = 'roleDelete';
     once = false;
 
-    async execute(role: Role): Promise<any> {
+    async execute(role: Role): Promise<void> {
         await this.roleDeleteHandler(role);
     }
 

--- a/src/app/events/RoleUpdate.ts
+++ b/src/app/events/RoleUpdate.ts
@@ -8,7 +8,7 @@ export default class implements DiscordEvent {
     name = 'roleUpdate';
     once = false;
 
-    async execute(oldRole: Role, newRole: Role): Promise<any> {
+    async execute(oldRole: Role, newRole: Role): Promise<void> {
         await this.roleUpdateHandler(oldRole, newRole);
     }
 

--- a/src/app/events/RoleUpdate.ts
+++ b/src/app/events/RoleUpdate.ts
@@ -1,0 +1,25 @@
+import { Role } from "discord.js";
+import { upsertCustomerRoles } from "../activity/roles/CustomerRoles";
+import { UpsertCustomerRolesRequest } from "../requests/UpsertCustomerRolesRequest";
+import { DiscordEvent } from "../types/discord/DiscordEvent";
+import { LogUtils } from "../utils/Log";
+
+export default class implements DiscordEvent {
+    name = 'roleUpdate';
+    once = false;
+
+    async execute(oldRole: Role, newRole: Role): Promise<any> {
+        await this.roleUpdateHandler(oldRole, newRole);
+    }
+
+    async roleUpdateHandler(oldRole: Role, newRole: Role) {
+        const request = await UpsertCustomerRolesRequest.build(newRole);
+
+        try {
+            await upsertCustomerRoles(request)
+        } catch (e) {
+            LogUtils.logError('Updating Customer Roles failed', e);
+        }
+    }
+
+}

--- a/src/app/requests/UpsertCustomerRolesRequest.ts
+++ b/src/app/requests/UpsertCustomerRolesRequest.ts
@@ -1,0 +1,33 @@
+import { Role } from "discord.js";
+import RuntimeError from "../errors/RuntimeError";
+import DiscordUtils from "../utils/DiscordUtils";
+
+export class UpsertCustomerRolesRequest {
+    customerId: string;
+    customerName: string;
+
+    constructor(args: {
+        role: Role,
+        customerName: string,
+    }) {
+        if (args.role) {
+            this.customerId = args.role.guild.id;
+        }
+        else {
+            throw new RuntimeError(new Error('Attempted UpsertCustomerRolesRequest without a role specified.'));
+        }
+
+        if (args.customerName) {
+            this.customerName = args.customerName;
+        }
+    }
+
+    static async build(role: Role) {
+        const customerName = await DiscordUtils.getGuildNameFromGuildId(role.guild.id);
+        return new UpsertCustomerRolesRequest({
+            role: role,
+            customerName: customerName,
+        });
+    }
+
+}

--- a/src/app/types/roles/CustomerRolesCollection.ts
+++ b/src/app/types/roles/CustomerRolesCollection.ts
@@ -1,0 +1,9 @@
+import { Collection, ObjectId } from 'mongodb';
+
+export interface CustomerRolesCollection extends Collection {
+	_id: ObjectId,
+    customerId: string,
+    roles: {
+        rolesMap: object,
+    }
+}

--- a/src/app/types/roles/CustomerRolesCollection.ts
+++ b/src/app/types/roles/CustomerRolesCollection.ts
@@ -1,9 +1,10 @@
+import { Snowflake } from 'discord-api-types';
 import { Collection, ObjectId } from 'mongodb';
 
 export interface CustomerRolesCollection extends Collection {
 	_id: ObjectId,
     customerId: string,
     roles: {
-        rolesMap: object,
+        rolesMap: Record<Snowflake, string>,
     }
 }

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -17,6 +17,21 @@ const DiscordUtils = {
         return await guild.roles.fetch(roleId);
     },
 
+    async getRolesFromGuildId(guildId: string): Promise<Collection<Snowflake, Role>> {
+        const guild = await client.guilds.fetch(guildId);
+        return guild.roles.cache;
+    },
+
+    async verifyOnlineFromGuildId(guildId: string) : Promise<boolean> {
+        const guild = await client.guilds.fetch(guildId);
+        return guild.available;
+    },
+
+    async getGuildNameFromGuildId(guildId: string): Promise<string> {
+        const guild = await client.guilds.fetch(guildId);
+        return guild.name;
+    },
+
     async getGuildAndMember(guildId: string, userId: string): Promise<{ guild: Guild, guildMember: GuildMember }> {
         const guild = await client.guilds.fetch(guildId);
         return {


### PR DESCRIPTION
…omer.roles collection on role create delete and update events.

With the discord.js library, our bot has two complementary, but distinct features:
* The ability to fetch all roles for a given guild that the bot has necessary permissions for
* The ability to listen for and respond to role creation, update, and deletion events for all guilds the bot client is registered to

When we put these together, it makes our bot the best candidate for updating a `customer.roles` collection: an up-to-date list of all roles for a given customer. This collection will be consumed by our web application in the bounty creation flow, so that users can select roles to gate a bounty to by *role name* and not role id. 

The data schema for this new collection is:
```
{
_id: ObjectId,
customerId: string,
roles: {
  roleMap: { 
    [roleId: string, 
    roleName: string]
  }
}

}
```

After this change, listeners are now implemented for: 
RoleCreate, RoleUpdate, RoleDelete
https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-roleCreate

This change also experiments with adding an `static async build` to fetch a name for a given guildId in the new `UpsertCustomerRolesRequest` request type. This is something I avoided in the original `request/bounty/` types, but is probably here to stay. I'm thinking it will be implemented across the bounty request types to facilitate adding metadata to our loggers to facilitate setting a mandatory `id` and `name` of a `Validation` or `Runtime` error explicitly rather than implicitly through an error message (think ``` `{request.guildId} {request.guildName} failed to publish bounty` ```). Currently all events and commands happen in the context of a guild, so this is sensible. 
