### PR TITLE
feature/wallet: implemented register-wallet activity and command

### DIFF
--- a/src/app/activity/bounty/ActivityHandler.ts
+++ b/src/app/activity/bounty/ActivityHandler.ts
@@ -30,6 +30,8 @@ import { HelpRequest } from '../../requests/HelpRequest';
 import { Activities } from '../../constants/activities';
 import DiscordUtils from '../../utils/DiscordUtils';
 import { GmRequest } from '../../requests/GmRequest'
+import { UpsertUserWalletRequest } from '../../requests/UpsertUserWalletRequest'
+import { upsertUserWallet } from '../user/RegisterWallet'
 
 export const BountyActivityHandler = {
     /**
@@ -79,6 +81,9 @@ export const BountyActivityHandler = {
                 break;
             case Activities.help:
                 await helpBounty(request as HelpRequest);
+                break;
+            case Activities.registerWallet:
+                await upsertUserWallet(request as UpsertUserWalletRequest);
                 break;
             case 'gm':
                 let gmRequest: GmRequest = request;

--- a/src/app/activity/user/RegisterWallet.ts
+++ b/src/app/activity/user/RegisterWallet.ts
@@ -1,0 +1,35 @@
+import { Db, UpdateWriteOpResult } from "mongodb";
+import { UpsertUserWalletRequest } from "../../requests/UpsertUserWalletRequest";
+import { UserCollection } from "../../types/user/UserCollection";
+import MongoDbUtils from "../../utils/MongoDbUtils";
+import Log from "../../utils/Log";
+
+export const upsertUserWallet = async (request: UpsertUserWalletRequest): Promise<any> => {
+    return await dbHandler(request);
+}
+
+const dbHandler = async (request: UpsertUserWalletRequest): Promise<void> => {
+    const db: Db = await MongoDbUtils.connect('bountyboard');
+    const userCollection = db.collection('user');
+
+	const dbUserResult: UserCollection = await userCollection.findOne({
+		userDiscordId: request.userDiscordId,
+	});
+
+    if (!dbUserResult) {
+        await userCollection.insertOne({
+            userDiscordId: request.userDiscordId,
+        })
+    }
+
+	const writeResult: UpdateWriteOpResult = await userCollection.updateOne({userDiscordId: request.userDiscordId }, {
+		$set: {
+			walletAddress: request.address,
+		},
+	});
+
+    if (writeResult.result.ok !== 1) {
+        Log.error(`Write result did not execute correctly`);
+        throw new Error(`Write to database for user ${request.userDiscordId}: ${request.address} failed`);
+    }
+}

--- a/src/app/auth/commandAuth.ts
+++ b/src/app/auth/commandAuth.ts
@@ -56,6 +56,8 @@ const AuthorizationModule = {
                 return deleteAuthorization(request as DeleteRequest);
             case Activities.help:
                 return help(request as HelpRequest);
+            case Activities.registerWallet:
+                return;
 			case 'gm':
                 return;
         }

--- a/src/app/commands/bounty/Wallet.ts
+++ b/src/app/commands/bounty/Wallet.ts
@@ -1,0 +1,89 @@
+import {
+    CommandContext,
+    CommandOptionType,
+    SlashCommand,
+    SlashCreator,
+} from 'slash-create';
+import { handler } from '../../activity/bounty/Handler';
+
+import ValidationError from '../../errors/ValidationError';
+import AuthorizationError from '../../errors/AuthorizationError';
+import Log, { LogUtils } from '../../utils/Log';
+import { Request } from '../../requests/Request';
+import { guildIds } from '../../constants/customerIds';
+import { Activities } from '../../constants/activities';
+import { UpsertUserWalletRequest } from '../../requests/UpsertUserWalletRequest';
+import DiscordUtils from '../../utils/DiscordUtils';
+
+export default class Wallet extends SlashCommand {
+    constructor(creator: SlashCreator) {
+        super(creator, {
+            name: Activities.registerWallet,
+            description: 'Register your wallet address to get paid by bounty creators.',
+            //TODO: make this dynamic? - can pull guildId list by querying mongo from app.ts on startup
+            guildIDs: guildIds,
+            options: [
+                    {
+                        name: 'eth-wallet-address',
+                        type: CommandOptionType.STRING,
+                        description: 'Enter your ethereum wallet address',
+                        required: true,
+                    },
+                ],
+            throttling: {
+                usages: 2,
+                duration: 1,
+            },
+            defaultPermission: true,
+        });
+    }
+
+    /**
+     * Transform slash command to activity request and route through the correct handlers.
+     * Responsible for graceful error handling and status messages.
+     * Wrap all received error messages with a user mention.
+     * 
+     * @param commandContext 
+     * @returns empty promise for async calls
+     */
+    async run(commandContext: CommandContext): Promise<any> {
+        // TODO: migrate to adding handlers to array
+        // core-logic of any Activity:
+        // request initiator (slash command, message reaction, dm reaction callback)
+        // Auth check
+        // validate/sanitize user input
+        // Parse user input into database/api call
+        // Successful db/API response --> user success handling + embed update, allow request initiator to delete original /bounty message
+        // Error db/API response --> throw error, allow request initiator to handle logging, and graceful error message to users
+        Log.debug(`Slash command triggered for ${commandContext.subcommands[0]}`);
+
+        const request = new UpsertUserWalletRequest({
+            userDiscordId: commandContext.user.id,
+            address: commandContext.options['eth-wallet-address']
+
+        })
+        //const { guildMember } = await DiscordUtils.getGuildAndMember(commandContext.guildID, commandContext.user.id);
+
+        try {
+            await handler(request)
+        }
+        catch (e) {
+            if (e instanceof ValidationError) {
+                await commandContext.send(`<@${commandContext.user.id}>\n` + e.message, { ephemeral: true });
+                return;
+            } else if (e instanceof AuthorizationError) {
+                await commandContext.send(`<@${commandContext.user.id}>\n` + e.message, { ephemeral: true });
+                return;
+            }
+            else {
+                LogUtils.logError('error', e);
+                await commandContext.send('Sorry something is not working and our devs are looking into it.', { ephemeral: true });
+                await commandContext.delete();
+                return;
+            }
+        }
+
+        return await commandContext.send(`<@${request.userDiscordId}>, registered wallet address ${request.address}`, { ephemeral: true });
+
+    }
+}

--- a/src/app/constants/activities.ts
+++ b/src/app/constants/activities.ts
@@ -10,4 +10,5 @@ export class Activities {
     static list = 'list';
     static paid = 'paid';
     static help = 'help';
+    static registerWallet = 'register-wallet';
 }

--- a/src/app/requests/UpsertUserWalletRequest.ts
+++ b/src/app/requests/UpsertUserWalletRequest.ts
@@ -1,0 +1,21 @@
+import { Activities } from '../constants/activities';
+
+export class UpsertUserWalletRequest {
+    userDiscordId: string;
+    address: string;
+    activity: string;
+
+    constructor(args: {
+        userDiscordId: string,
+        address: string,
+    }) {
+        if (args.userDiscordId && args.address) {
+            this.userDiscordId = args.userDiscordId;
+            this.address = args.address;
+            this.activity = Activities.registerWallet;
+        }
+        else {
+            throw new Error("userDiscordId and address must both be set");
+        }
+    }
+}

--- a/src/app/types/user/UserCollection.ts
+++ b/src/app/types/user/UserCollection.ts
@@ -1,4 +1,3 @@
-import { Snowflake } from 'discord-api-types';
 import { Collection, ObjectId } from 'mongodb';
 
 export interface UserCollection extends Collection {

--- a/src/app/types/user/UserCollection.ts
+++ b/src/app/types/user/UserCollection.ts
@@ -1,0 +1,8 @@
+import { Snowflake } from 'discord-api-types';
+import { Collection, ObjectId } from 'mongodb';
+
+export interface UserCollection extends Collection {
+	_id: ObjectId,
+    userDiscordId: string,
+    walletAddress: string,
+}

--- a/src/app/utils/WalletUtils.ts
+++ b/src/app/utils/WalletUtils.ts
@@ -1,0 +1,12 @@
+import ValidationError from "../errors/ValidationError";
+const WalletUtils = {
+    validateEthereumWalletAddress(address: string): void {
+        const ETHEREUM_WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/g;
+        if (address == null || !ETHEREUM_WALLET_REGEX.test(address)) {
+            throw new ValidationError(
+                'Please enter a valid etheruem address: \n');
+        }
+    } 
+}
+
+export default WalletUtils;

--- a/src/app/utils/WalletUtils.ts
+++ b/src/app/utils/WalletUtils.ts
@@ -4,7 +4,7 @@ const WalletUtils = {
         const ETHEREUM_WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/g;
         if (address == null || !ETHEREUM_WALLET_REGEX.test(address)) {
             throw new ValidationError(
-                'Please enter a valid etheruem address: \n');
+                'Please enter a valid ethereum address\n');
         }
     } 
 }

--- a/src/app/validation/commandValidation.ts
+++ b/src/app/validation/commandValidation.ts
@@ -1,5 +1,6 @@
 import ValidationError from '../errors/ValidationError';
 import BountyUtils from '../utils/BountyUtils';
+import WalletUtils from '../utils/WalletUtils';
 import Log, { LogUtils } from '../utils/Log';
 import mongo, { Db } from 'mongodb';
 import MongoDbUtils from '../utils/MongoDbUtils';
@@ -17,6 +18,7 @@ import { CompleteRequest } from '../requests/CompleteRequest';
 import { PaidRequest } from '../requests/PaidRequest';
 import { HelpRequest } from '../requests/HelpRequest';
 import { DeleteRequest } from '../requests/DeleteRequest';
+import { UpsertUserWalletRequest } from '../requests/UpsertUserWalletRequest';
 
 
 const ValidationModule = {
@@ -50,6 +52,8 @@ const ValidationModule = {
                 return deleteValidation(request as DeleteRequest);
             case Activities.help:
                 return help(request as HelpRequest);
+            case Activities.registerWallet:
+                return registerWallet(request as UpsertUserWalletRequest);
             case 'gm':
                 return;
             default:
@@ -381,5 +385,13 @@ const help = async (request: HelpRequest): Promise<void> => {
             throw new ValidationError(`Please select a valid bounty id to request ${request.activity}. ` +
                 'Check your previous DMs from bountybot for the correct id.')
         }
+    }
+}
+
+const registerWallet = async (request: UpsertUserWalletRequest): Promise<void> => {
+    Log.debug(`Validating activity ${request.activity}`);
+
+    if (request.address) {
+        WalletUtils.validateEthereumWalletAddress(request.address)
     }
 }


### PR DESCRIPTION
Incremental PR, part of the overall story to be able to generate a csv of transactions that can be uploaded to Parcel or gnosis to facilitate easy payment of bounties.

This PR is concerned with the modular step of associating a user with their preferred wallet address. 

The command is a root level command called `/register-wallet`

<img width="879" alt="Screen Shot 2022-02-17 at 1 02 21 AM" src="https://user-images.githubusercontent.com/85538143/154415476-cbba482d-ef37-4808-88d6-7fc95c7c5690.png">

Interactions with users are handled through ephemeral messages: read only messages that are viewable only to the user. The below screenshot shows happy and negative path responses (wallet address redacted)

<img width="879" alt="Screen Shot 2022-02-17 at 1 07 57 AM" src="https://user-images.githubusercontent.com/85538143/154415896-3ec6b5df-8cca-4e82-a656-57b39195e80a.png">

Note: the screenshots have a misspelling of `ethereum`, but that is corrected in the PR