### PR TITLE
feature/tagging:

### DIFF
--- a/src/app/activity/bounty/ActivityHandler.ts
+++ b/src/app/activity/bounty/ActivityHandler.ts
@@ -10,6 +10,8 @@ import { paidBounty } from './Paid'
 import { listBounty } from './List'
 import { deleteBounty } from './Delete'
 import { helpBounty } from './Help'
+import { upsertUserWallet } from '../user/RegisterWallet';
+import { tagBounty } from './Tag';
 
 
 import { Guild, GuildMember } from 'discord.js';
@@ -31,7 +33,7 @@ import { Activities } from '../../constants/activities';
 import DiscordUtils from '../../utils/DiscordUtils';
 import { GmRequest } from '../../requests/GmRequest'
 import { UpsertUserWalletRequest } from '../../requests/UpsertUserWalletRequest'
-import { upsertUserWallet } from '../user/RegisterWallet'
+import { TagRequest } from '../../requests/TagRequest'
 
 export const BountyActivityHandler = {
     /**
@@ -84,6 +86,9 @@ export const BountyActivityHandler = {
                 break;
             case Activities.registerWallet:
                 await upsertUserWallet(request as UpsertUserWalletRequest);
+                break;
+            case Activities.tag:
+                await tagBounty(request as TagRequest);
                 break;
             case 'gm':
                 let gmRequest: GmRequest = request;

--- a/src/app/activity/bounty/Tag.ts
+++ b/src/app/activity/bounty/Tag.ts
@@ -1,0 +1,22 @@
+import mongo, { Db, UpdateWriteOpResult } from "mongodb";
+import { TagRequest } from "../../requests/TagRequest";
+import { BountyCollection } from "../../types/bounty/BountyCollection";
+import Log from "../../utils/Log"
+import MongoDbUtils from "../../utils/MongoDbUtils";
+
+export const tagBounty = async (request: TagRequest): Promise<void> => {
+    Log.debug(`In Tag activity`);
+
+    return await writeDbHandler(request);
+}
+
+const writeDbHandler = async (request: TagRequest): Promise<void> => {
+    const db: Db = await MongoDbUtils.connect('bountyboard');
+	const bountyCollection = db.collection('bounties');
+
+	const writeResult: UpdateWriteOpResult = await bountyCollection.updateOne( {_id: new mongo.ObjectId(request.bountyId)}, {
+		$set: {
+			tag: request.tag,
+		},
+	});
+}

--- a/src/app/auth/commandAuth.ts
+++ b/src/app/auth/commandAuth.ts
@@ -18,6 +18,7 @@ import { BountyStatus } from '../constants/bountyStatus';
 import { HelpRequest } from '../requests/HelpRequest';
 import { DeleteRequest } from '../requests/DeleteRequest';
 import { PaidRequest } from '../requests/PaidRequest';
+import { TagRequest } from '../requests/TagRequest';
 
 const AuthorizationModule = {
     /**
@@ -58,6 +59,8 @@ const AuthorizationModule = {
                 return help(request as HelpRequest);
             case Activities.registerWallet:
                 return;
+            case Activities.tag:
+                return tag(request as TagRequest)
 			case 'gm':
                 return;
         }
@@ -262,6 +265,24 @@ const help = async (request: HelpRequest): Promise<void> => {
                 `Please reach out to your favorite bounty board representative with any questions!` 
                 );
         }
+    }
+}
+
+const tag = async (request: TagRequest): Promise<void> => {
+    const db: Db = await MongoDbUtils.connect('bountyboard');
+    const bountyCollection = db.collection('bounties');
+    const dbBountyResult: BountyCollection = await bountyCollection.findOne({
+        _id: new mongo.ObjectId(request.bountyId),
+    });
+
+    if (request.userId !== dbBountyResult.createdBy.discordId) {
+        throw new AuthorizationError(
+            `Thank you for giving bounty commands a try!\n` +
+            `It looks like you don't have permission to ${request.activity} this bounty.\n` +
+            `This bounty can only be tagged by <@${dbBountyResult.createdBy.discordId}>. \n` +
+            `At this time, you can only tag bounties that you have created.\n` +
+            `Please reach out to your favorite bounty board representative with any questions!` 
+            );
     }
 }
 

--- a/src/app/commands/bounty/Bounty.ts
+++ b/src/app/commands/bounty/Bounty.ts
@@ -24,6 +24,7 @@ import { GmRequest } from '../../requests/GmRequest';
 import AuthorizationError from '../../errors/AuthorizationError';
 import DiscordUtils from '../../utils/DiscordUtils';
 import { guildIds } from '../../constants/customerIds';
+import { TagRequest } from '../../requests/TagRequest';
 
 
 export default class Bounty extends SlashCommand {
@@ -181,6 +182,25 @@ export default class Bounty extends SlashCommand {
                             name: 'bounty-id',
                             type: CommandOptionType.STRING,
                             description: 'Bounty ID',
+                            required: true,
+                        },
+                    ],
+                },
+                {
+                    name: Activities.tag,
+                    type: CommandOptionType.SUB_COMMAND,
+                    description: 'Tag this bounty. Useful to group similar bounties for csv payments.',
+                    options: [
+                        {
+                            name: 'bounty-id',
+                            type: CommandOptionType.STRING,
+                            description: 'Bounty ID',
+                            required: true,
+                        },
+                        {
+                            name: 'tag',
+                            type: CommandOptionType.STRING,
+                            description: 'Tag (i.e. \'Note Taking: January\' ',
                             required: true,
                         },
                     ],
@@ -346,6 +366,12 @@ export default class Bounty extends SlashCommand {
                 break;
             case Activities.help:
                 request = new HelpRequest({
+                    commandContext: commandContext,
+                    messageReactionRequest: null
+                });
+                break;
+            case Activities.tag:
+                request = new TagRequest({
                     commandContext: commandContext,
                     messageReactionRequest: null
                 });

--- a/src/app/constants/activities.ts
+++ b/src/app/constants/activities.ts
@@ -11,4 +11,5 @@ export class Activities {
     static paid = 'paid';
     static help = 'help';
     static registerWallet = 'register-wallet';
+    static tag = 'tag';
 }

--- a/src/app/requests/TagRequest.ts
+++ b/src/app/requests/TagRequest.ts
@@ -1,0 +1,34 @@
+import { CommandContext } from 'slash-create';
+import { Request } from './Request';
+import { MessageReactionRequest } from '../types/discord/MessageReactionRequest';
+import { Activities } from '../constants/activities';
+import { Message } from 'discord.js';
+import DiscordUtils from '../utils/DiscordUtils';
+
+export class TagRequest extends Request {
+    bountyId: string;
+    tag: string;
+    
+    commandContext: CommandContext;
+    message: Message;
+
+    constructor(args: {
+        commandContext: CommandContext, 
+        messageReactionRequest: MessageReactionRequest
+    }) {
+        if (args.commandContext) {
+            if (args.commandContext.subcommands[0] !== Activities.tag) {
+                throw new Error(`${Activities.tag}Request created for non ${Activities.tag} activity.`);
+            }
+            super(args.commandContext.subcommands[0], args.commandContext.guildID, args.commandContext.user.id, args.commandContext.user.bot);
+            this.commandContext = args.commandContext;
+            this.bountyId = args.commandContext.options.tag['bounty-id'];
+            this.tag = args.commandContext.options.tag['tag'];
+        } else if (args.messageReactionRequest) {
+            const messageReactionRequest: MessageReactionRequest = args.messageReactionRequest;
+            super(Activities.tag, messageReactionRequest.message.guildId, messageReactionRequest.user.id, messageReactionRequest.user.bot);
+            this.message = messageReactionRequest.message;
+            this.bountyId = DiscordUtils.getBountyIdFromEmbedMessage(messageReactionRequest.message);
+        }
+    }
+}

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -54,6 +54,18 @@ const BountyUtils = {
         }
     },
 
+    validateTag(tag: string): void {
+        const CREATE_TAG_REGEX = /^[\w\s\W]{1,80}$/;
+        if (tag == null || !CREATE_TAG_REGEX.test(tag)) {
+            throw new ValidationError(
+                'Please enter a valid tag: \n' +
+                '- 80 characters maximum\n ' +
+                '- alphanumeric\n ' +
+                '- special characters: .!@#$%&,?:|-_',
+            );
+        }
+    },
+
     validateReward(rewardInput: string): void {
         const [stringAmount, symbol] = (rewardInput != null) ? rewardInput.split(' ') : [null, null];
         const ALLOWED_CURRENCIES = ['BANK', 'ETH', 'BTC', 'USDC', 'USDT', 'TempCity', 'gOHM', 'LUSD', 'FOX', 'oneFOX'];


### PR DESCRIPTION
 Note: This is an incremental unit of work. Future PRs on this branch will incorporate tagging into list functionality, lifecycle commands, and find a smart way to store the tag values on the bounty cards.
 
 Implemented command, request, validation, authorization, and write handler

Originally, I was going to wait to open this PR until I had incorporated tagging into the create flow and into list functionality, but before I start that unit of work, I think it's sensible to get this first step merged in.

This PR creates a slash command for a user to provide a bounty id, and tag it. The idea is that a bounty power user like @Icedcool can tag a bounty with a budget or project specifier. Think "Bounty Board External Contributor Bounty March 2021" 

In this PR, tags are upserted values. If/when users find this feature helpful, we can implement an array of tags, as well as a sensible way to remove tags on the bot (on the web client, that's a fairly trivial problem to solve)