### PR TITLE
feature/WalletFlow: implemented synchronous wallet collection for claimant

### DIFF
--- a/src/app/activity/bounty/Claim.ts
+++ b/src/app/activity/bounty/Claim.ts
@@ -1,4 +1,4 @@
-import { GuildMember, Message, DMChannel, AwaitMessagesOptions } from 'discord.js';
+import { GuildMember, Message, DMChannel } from 'discord.js';
 import { ClaimRequest } from '../../requests/ClaimRequest';
 import { BountyCollection } from '../../types/bounty/BountyCollection';
 import DiscordUtils from '../../utils/DiscordUtils';
@@ -10,12 +10,6 @@ import { BountyStatus } from '../../constants/bountyStatus';
 import BountyUtils from '../../utils/BountyUtils';
 import { Activities } from '../../constants/activities';
 import { Clients } from '../../constants/clients';
-import { CommandContext } from 'slash-create';
-import ValidationError from '../../errors/ValidationError';
-import WalletUtils from '../../utils/WalletUtils';
-import { UpsertUserWalletRequest } from '../../requests/UpsertUserWalletRequest';
-import { Request } from '../../requests/Request';
-import { handler } from './Handler';
 import { UserCollection } from '../../types/user/UserCollection';
 
 export const claimBounty = async (request: ClaimRequest): Promise<any> => {
@@ -32,11 +26,11 @@ export const claimBounty = async (request: ClaimRequest): Promise<any> => {
     
         const claimWalletMessage = `Hello <@${request.userId}>!\n` +
             `Please respond within 2 minutes.\n` +
-            `Please enter the ethereum wallet address (non-ENS) to receive the reward amount for this bounty`;
+            `To claim this bounty, please enter the ethereum wallet address (non-ENS) to receive the reward amount for this bounty`;
         const walletNeededMessage: Message = await claimedByUser.send({ content: claimWalletMessage });
         const dmChannel: DMChannel = await walletNeededMessage.channel.fetch() as DMChannel;
     
-        await BountyUtils.userInputWalletAddress(dmChannel, request.userId);
+        await BountyUtils.userInputWalletAddress(dmChannel, request.userId, request.guildId);
     }
 
     let getDbResult: {dbBountyResult: BountyCollection, bountyChannel: string} = await getDbHandler(request);

--- a/src/app/activity/bounty/Claim.ts
+++ b/src/app/activity/bounty/Claim.ts
@@ -1,4 +1,4 @@
-import { GuildMember } from 'discord.js';
+import { GuildMember, Message, DMChannel, AwaitMessagesOptions } from 'discord.js';
 import { ClaimRequest } from '../../requests/ClaimRequest';
 import { BountyCollection } from '../../types/bounty/BountyCollection';
 import DiscordUtils from '../../utils/DiscordUtils';
@@ -10,13 +10,35 @@ import { BountyStatus } from '../../constants/bountyStatus';
 import BountyUtils from '../../utils/BountyUtils';
 import { Activities } from '../../constants/activities';
 import { Clients } from '../../constants/clients';
+import { CommandContext } from 'slash-create';
+import ValidationError from '../../errors/ValidationError';
+import WalletUtils from '../../utils/WalletUtils';
+import { UpsertUserWalletRequest } from '../../requests/UpsertUserWalletRequest';
+import { Request } from '../../requests/Request';
+import { handler } from './Handler';
+import { UserCollection } from '../../types/user/UserCollection';
 
 export const claimBounty = async (request: ClaimRequest): Promise<any> => {
     Log.debug('In Claim activity');
 
     const claimedByUser = await DiscordUtils.getGuildMemberFromUserId(request.userId, request.guildId);
     Log.info(`${request.bountyId} bounty claimed by ${claimedByUser.user.tag}`);
+
+    if (! (await isUserWalletRegistered(request))) {
+        if (request.commandContext) {
+            const gotoDMMessage = 'Go to your DMs to finish claiming the bounty...';
+            await request.commandContext.send({ content: gotoDMMessage, ephemeral: true});
+        }
     
+        const claimWalletMessage = `Hello <@${request.userId}>!\n` +
+            `Please respond within 2 minutes.\n` +
+            `Please enter the ethereum wallet address (non-ENS) to receive the reward amount for this bounty`;
+        const walletNeededMessage: Message = await claimedByUser.send({ content: claimWalletMessage });
+        const dmChannel: DMChannel = await walletNeededMessage.channel.fetch() as DMChannel;
+    
+        await BountyUtils.userInputWalletAddress(dmChannel, request.userId);
+    }
+
     let getDbResult: {dbBountyResult: BountyCollection, bountyChannel: string} = await getDbHandler(request);
 
     let claimedBounty = getDbResult.dbBountyResult;
@@ -54,6 +76,18 @@ export const claimBounty = async (request: ClaimRequest): Promise<any> => {
     
     return;
 };
+
+const isUserWalletRegistered = async (request: ClaimRequest): Promise<boolean> => {
+    const db: Db = await MongoDbUtils.connect('bountyboard');
+    const userCollection = db.collection('user');
+
+    const dbUserResult: UserCollection = await userCollection.findOne({
+        userDiscordId: request.userId
+    });
+
+    if (dbUserResult && dbUserResult.walletAddress) return true;
+    return false;
+}
 
 const getDbHandler = async (request: ClaimRequest): Promise<{dbBountyResult: BountyCollection, bountyChannel: string}> => {
     const db: Db = await MongoDbUtils.connect('bountyboard');

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -116,7 +116,7 @@ const DiscordUtils = {
              throw new ValidationError(
                  'You have timed out!\nPlease retry claiming this bounty.\n' +
                  'You can also run `/register wallet` to register your wallet address.\n' +
-                 'Please to do so to help the bounty creator reward you for this bounty.\n' +
+                 'Please do so to help the bounty creator reward you for this bounty.\n' +
                  'Reach out to your favorite Bounty Board representative with any questions.\n'
              );
         }

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -107,6 +107,34 @@ const DiscordUtils = {
 		return messageText;
 	},
 
+    async awaitUserWalletDM(dmChannel: DMChannel, replyOptions: AwaitMessagesOptions): Promise<string> {
+        let messages: Collection<Snowflake, Message> = null;
+        try {
+         messages = await dmChannel.awaitMessages(replyOptions);
+         // TODO: this is too broad
+         } catch (e) {
+             throw new ValidationError(
+                 'You have timed out!\nPlease retry claiming this bounty.\n' +
+                 'You can also run `/register wallet` to register your wallet address.\n' +
+                 'Please to do so to help the bounty creator reward you for this bounty.\n' +
+                 'Reach out to your favorite Bounty Board representative with any questions.\n'
+             );
+        }
+        const message = messages.first();
+		const messageText = message.content;
+
+		if(message.author.bot) {
+			throw new ValidationError(
+				'Detected bot response to last message! The previous operation has been discarded.\n' +
+				'Currently, you can only run one Bounty command at once.\n' +
+				'Be sure to check your DMs for any messages from Bountybot.\n' +
+				'Please reach out to your favorite Bounty Board representative with any questions.\n',
+			);
+		}
+
+		return messageText;
+	},
+
     // TODO: graceful timeout handling needed
     async awaitUser(channel: TextChannel, replyOptions: AwaitMessagesOptions): Promise<Message> {
         let messages: Collection<Snowflake, Message> = null;


### PR DESCRIPTION
Implemented a synchronous collection step for a claimant's wallet address. 

Wallet addresses are needed to build the CSVs to fulfill bounty transactions on platforms like Gnosis or Parcel. 

In the 1st version of this PR, if the user is unable to enter a valid wallet address, they are unable to claim the bounty. It's a little harsh, and I may update it so that's no longer a hard blocker to the claim activity. One good reason to not have a hard dependency is for new contributor onboarding (perhaps they don't have a wallet). One good reason to have a hard dependency is that the forced step will make payments for creators much easier as they no longer have to chase down wallet addresses (something that takes 24-48 hours from my personal experience).