### PR TITLE
feature/wallet-iou: ping the owed-to user after an IOU is created for a wallet address

### DIFF
--- a/src/app/activity/bounty/Create.ts
+++ b/src/app/activity/bounty/Create.ts
@@ -116,7 +116,28 @@ export const createBounty = async (createRequest: CreateRequest): Promise<any> =
 
     if (createRequest.isIOU) {
         // await createRequest.commandContext.sendFollowUp({ content: "Your IOU was created." } , { ephemeral: true });
-        await owedTo.send({ content: `An IOU was created for you by <@${guildMember.user.id}>: ${cardMessage.url}`});
+        await owedTo.send({ content: `<@${owedTo.id}> An IOU was created for you by <@${guildMember.user.id}>: ${cardMessage.url}`});
+
+        if (! (await BountyUtils.isUserWalletRegistered(owedTo.id))) {
+            // Note: ephemeral messagees are only visible to the user who kicked off the interaction,
+            // so we can not send an ephemeral message to the owedTo user to check DMs
+            
+            const durationMinutes = 5;
+            const iouWalletMessage = `Hello <@${owedTo.id}>!\n` +
+                `Please respond within ${durationMinutes} minutes.\n` +
+                `Please enter the ethereum wallet address (non-ENS) to receive the reward amount for this bounty`;
+            const walletNeededMessage: Message = await owedTo.send({ content: iouWalletMessage });
+            const dmChannel: DMChannel = await walletNeededMessage.channel.fetch() as DMChannel;
+            
+            await createRequest.commandContext.send({content: `Waiting for <@${owedTo.id}> to enter their wallet address.`, ephemeral: true});
+            if (! (await BountyUtils.userInputWalletAddress(dmChannel, createRequest.userId, durationMinutes*60*1000))) {
+                owedTo.send(
+                `Unable to complete this operation due to timeout or incorrect wallet addresses.\n` +
+                'Please try entering your wallet address with the slash command `/register wallet`.\n\n' +
+                `Return to Bounty list: ${(await BountyUtils.getLatestCustomerList(createRequest.guildId))}`
+                );
+            }
+        }
     } else {
 
         const publishOrDeleteMessage = 

--- a/src/app/activity/bounty/Create.ts
+++ b/src/app/activity/bounty/Create.ts
@@ -132,7 +132,7 @@ export const createBounty = async (createRequest: CreateRequest): Promise<any> =
             await createRequest.commandContext.send({content: `Waiting for <@${owedTo.id}> to enter their wallet address.`, ephemeral: true});
 
             try {
-                await BountyUtils.userInputWalletAddress(dmChannel, createRequest.userId, durationMinutes*60*1000);
+                await BountyUtils.userInputWalletAddress(dmChannel, owedTo.id, durationMinutes*60*1000);
                 await createRequest.commandContext.delete();
             }
             catch (e) {

--- a/src/app/activity/bounty/Create.ts
+++ b/src/app/activity/bounty/Create.ts
@@ -19,8 +19,6 @@ export const createBounty = async (createRequest: CreateRequest): Promise<any> =
 
     const guildAndMember = await DiscordUtils.getGuildAndMember(createRequest.guildId, createRequest.userId);
     const guildMember: GuildMember = guildAndMember.guildMember;
-    const guildId: string = guildAndMember.guild.id;
-    const commandChannel = DiscordUtils.getTextChannelfromChannelId(createRequest.commandContext.channelID);
 
     let newBounty: Bounty;
 
@@ -138,13 +136,18 @@ export const createBounty = async (createRequest: CreateRequest): Promise<any> =
                 await createRequest.commandContext.delete();
             }
             catch (e) {
-                if (e instanceof TimeoutError) {
+                if (e instanceof TimeoutError || e instanceof ValidationError) {
                     await owedTo.send(
                         `Unable to complete this operation due to timeout or incorrect wallet addresses.\n` +
                         'Please try entering your wallet address with the slash command `/register wallet`.\n\n' +
                         `Return to Bounty list: ${(await BountyUtils.getLatestCustomerList(createRequest.guildId))}`
                         );
-                    await createRequest.commandContext.delete();
+                    await createRequest.commandContext.editOriginal({content: 
+                        `<@${createRequest.userId}>:\n` +
+                        `<@${owedTo.id}> was unable to enter their wallet address.\n` + 
+                        `Collecting wallet addresses of contributors can take up to a few days.\n` +
+                        `To facilitate ease of payment when this bounty is completed, please remind <@${owedTo.id}> ` +
+                        'to register their wallet address with the slash command `/register wallet`\n'});
                 }
                 if (e instanceof ConflictingMessageException) {
                     await walletNeededMessage.delete();

--- a/src/app/errors/ConflictingMessageException.ts
+++ b/src/app/errors/ConflictingMessageException.ts
@@ -1,0 +1,8 @@
+export default class ConflictingMessageException extends Error {
+
+	constructor(message: string) {
+		super(message);
+
+		Object.setPrototypeOf(this, ConflictingMessageException.prototype);
+	}
+}

--- a/src/app/errors/TimeoutError.ts
+++ b/src/app/errors/TimeoutError.ts
@@ -1,0 +1,8 @@
+export default class TimeoutError extends Error {
+
+	constructor(operation: string) {
+		super(`Event handler for ${operation} has timed out`);
+
+		Object.setPrototypeOf(this, TimeoutError.prototype);
+	}
+}

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -15,8 +15,6 @@ import { CustomerCollection } from '../types/bounty/CustomerCollection';
 import { UpsertUserWalletRequest } from '../requests/UpsertUserWalletRequest';
 import { handler } from '../activity/bounty/Handler';
 import { UserCollection } from '../types/user/UserCollection';
-import TimeoutError from '../errors/TimeoutError';
-import ConflictingMessageException from '../errors/ConflictingMessageException';
 
 
 const BountyUtils = {

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -9,6 +9,7 @@ import { Db } from 'mongodb';
 import { CustomerCollection } from '../types/bounty/CustomerCollection';
 import { CommandContext } from 'slash-create';
 import { BountyCollection } from '../types/bounty/BountyCollection';
+import TimeoutError from '../errors/TimeoutError';
 
 
 
@@ -113,12 +114,7 @@ const DiscordUtils = {
          messages = await dmChannel.awaitMessages(replyOptions);
          // TODO: this is too broad
          } catch (e) {
-             throw new ValidationError(
-                 'You have timed out!\nPlease retry claiming this bounty.\n' +
-                 'You can also run `/register wallet` to register your wallet address.\n' +
-                 'Please do so to help the bounty creator reward you for this bounty.\n' +
-                 'Reach out to your favorite Bounty Board representative with any questions.\n'
-             );
+             throw new TimeoutError('awaitUserWalletDM');
         }
         const message = messages.first();
 		const messageText = message.content;

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -8,7 +8,6 @@ import MongoDbUtils  from '../utils/MongoDbUtils';
 import { Db } from 'mongodb';
 import { CustomerCollection } from '../types/bounty/CustomerCollection';
 import { CommandContext } from 'slash-create';
-import { BountyCollection } from '../types/bounty/BountyCollection';
 import TimeoutError from '../errors/TimeoutError';
 import ConflictingMessageException from '../errors/ConflictingMessageException';
 

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -10,6 +10,7 @@ import { CustomerCollection } from '../types/bounty/CustomerCollection';
 import { CommandContext } from 'slash-create';
 import { BountyCollection } from '../types/bounty/BountyCollection';
 import TimeoutError from '../errors/TimeoutError';
+import ConflictingMessageException from '../errors/ConflictingMessageException';
 
 
 
@@ -111,21 +112,22 @@ const DiscordUtils = {
     async awaitUserWalletDM(dmChannel: DMChannel, replyOptions: AwaitMessagesOptions): Promise<string> {
         let messages: Collection<Snowflake, Message> = null;
         try {
-         messages = await dmChannel.awaitMessages(replyOptions);
+            messages = await dmChannel.awaitMessages(replyOptions);
          // TODO: this is too broad
-         } catch (e) {
-             throw new TimeoutError('awaitUserWalletDM');
+        } 
+        catch (e) {
+            throw new TimeoutError('awaitUserWalletDM');
         }
         const message = messages.first();
 		const messageText = message.content;
 
-		if(message.author.bot) {
-			throw new ValidationError(
-				'Detected bot response to last message! The previous operation has been discarded.\n' +
-				'Currently, you can only run one Bounty command at once.\n' +
+		if (message.author.bot) {
+			throw new ConflictingMessageException(
+                'Detected bot response to last message! The previous bounty has been discarded.\n' +
+				'Currently, you can only run one Bounty create command at once.\n' +
 				'Be sure to check your DMs for any messages from Bountybot.\n' +
 				'Please reach out to your favorite Bounty Board representative with any questions.\n',
-			);
+            );
 		}
 
 		return messageText;


### PR DESCRIPTION
The main goal for this unit of work is to ping the recipient of an IOU to enter their wallet address if not already stored to their user profile for Bounty Board.

Given its similarity to a previous unit of work with #33 there were some additional changes:
* Moving the collection of wallet addresses to a utility function
* Removing error handling from the shared wallet address functionality and placing them in the activity. This is b/c in `Claim`, throwing a `ValidationError` will trigger proper error handling (bubbling up to the user who kicked off the interaction). However, in `Create`, this is not the right behavior, and we instead want to notify the recipient of the IOU. 
* Creating a utility (eventually will be refactored with our API) to fetch the latest bounty list message