### PR TITLE
Changes for web compatibility

### DIFF
--- a/src/app/activity/bounty/Apply.ts
+++ b/src/app/activity/bounty/Apply.ts
@@ -40,7 +40,10 @@ export const applyBounty = async (request: ApplyRequest): Promise<any> => {
     const appliedForBounty = await writeDbHandler(request, getDbResult.dbBountyResult, applyingUser, pitch);
     
     const cardMessage = await BountyUtils.canonicalCard(appliedForBounty._id, request.activity);
-    
+
+    // Update bounty with any web compatibility changes or conversions
+    BountyUtils.bountyCleanUp(appliedForBounty._id);
+
     const createdByUser: GuildMember = await applyingUser.guild.members.fetch(appliedForBounty.createdBy.discordId);
     let creatorDM = `Your bounty has been applied for by <@${applyingUser.id}> <${cardMessage.url}> \n` +
                         `Their pitch: ${pitch ? pitch : '<none given>'} \n` +
@@ -87,6 +90,7 @@ const writeDbHandler = async (request: ApplyRequest, appliedForBounty: BountyCol
             applicants: {
                 discordId: applyingUser.user.id,
                 discordHandle: applyingUser.user.tag,
+                iconUrl: applyingUser.user.avatarURL(),
                 pitch: pitch,
             },
         },

--- a/src/app/activity/bounty/Assign.ts
+++ b/src/app/activity/bounty/Assign.ts
@@ -33,7 +33,10 @@ export const assignBounty = async (request: AssignRequest): Promise<any> => {
     }
 
     const cardMessage = await BountyUtils.canonicalCard(getDbResult.dbBountyResult._id, request.activity);
-    
+
+    // Update bounty with any web compatibility changes or conversions
+    BountyUtils.bountyCleanUp(getDbResult.dbBountyResult._id);
+
     let assigningContent = `Your bounty has been assigned to <@${assignedUser.user.id}> ${cardMessage.url}`;
     let assignedContent = `You have been assigned this bounty! Go to the bounty card to claim it. Reach out to <@${assigningUser.id}> with any questions\n` +
     `<${cardMessage.url}>`;
@@ -75,8 +78,11 @@ const writeDbHandler = async (request: AssignRequest, assignedBounty: BountyColl
     
     const writeResult: UpdateWriteOpResult = await bountyCollection.updateOne(assignedBounty, {
         $set: {
-            assign: request.assign,
-            assignedName: assignedUser.user.tag
+            assignTo: {
+                discordId: request.assign,
+                discordHandle: assignedUser.user.tag,
+                iconUrl: assignedUser.user.avatarURL(),
+            },
         },
     });
 

--- a/src/app/activity/bounty/Claim.ts
+++ b/src/app/activity/bounty/Claim.ts
@@ -61,6 +61,9 @@ export const claimBounty = async (request: ClaimRequest): Promise<any> => {
     const parentBountyChannel = !parentBounty || !parentBounty.canonicalCard ? undefined : await DiscordUtils.getTextChannelfromChannelId(parentBounty.canonicalCard.channelId);
     const claimedBountyCard = await BountyUtils.canonicalCard(claimedBounty._id, request.activity, parentBountyChannel);
 
+    // Update bounty with any web compatibility changes or conversions
+    BountyUtils.bountyCleanUp(claimedBounty._id);
+
     let creatorNotification = 
     `Your bounty has been claimed by <@${claimedByUser.user.id}> <${claimedBountyCard.url}>\n` +
     `You are free to mark this bounty as complete and/or paid at any time.\n` +
@@ -68,6 +71,8 @@ export const claimBounty = async (request: ClaimRequest): Promise<any> => {
     if (getDbResult.dbBountyResult.evergreen) {
         const parentBountyUrl = process.env.BOUNTY_BOARD_URL + parentBounty._id;
         const parentBountyCard = await BountyUtils.canonicalCard(parentBounty._id, request.activity);
+        // Update bounty with any web compatibility changes or conversions
+        BountyUtils.bountyCleanUp(parentBounty._id);
         if (parentBounty.status == BountyStatus.open) {
             creatorNotification += `\nSince you marked your original bounty as multi-claimant, it will stay on the board as Open. <${parentBountyCard.url}>`;
         } else {

--- a/src/app/activity/bounty/Complete.ts
+++ b/src/app/activity/bounty/Complete.ts
@@ -34,6 +34,9 @@ export const completeBounty = async (request: CompleteRequest): Promise<void> =>
 	const submittedByUser = await completedByUser.guild.members.fetch(submittedByUserId);
     
     const cardMessage = await BountyUtils.canonicalCard(getDbResult.dbBountyResult._id, request.activity);
+
+	// Update bounty with any web compatibility changes or conversions
+	BountyUtils.bountyCleanUp(getDbResult.dbBountyResult._id);
 	
 	let creatorCompleteDM = 
         `Thank you for reviewing <${cardMessage.url}>\n` +

--- a/src/app/activity/bounty/List.ts
+++ b/src/app/activity/bounty/List.ts
@@ -141,10 +141,14 @@ export const listBounty = async (request: ListRequest): Promise<any> => {
 export const generateBountyFieldSegment = async (bountyRecord: BountyCollection, cardMessage: Message): Promise<any> => {
 	const url = !!cardMessage ? cardMessage.url : process.env.BOUNTY_BOARD_URL + bountyRecord._id
 	let forString = '';
-	if (bountyRecord.gate) {
+	if (bountyRecord.gateTo) {
+		forString = `claimable by role ${bountyRecord.gateTo[0].discordName}`;
+	} else if (bountyRecord.gate) {  // deprecated, replaced by gatedTo
 		const role = await DiscordUtils.getRoleFromRoleId(bountyRecord.gate[0], bountyRecord.customerId);
 		forString = `claimable by role ${role ? role.name : "<missing role>"}`;
-	} else if (bountyRecord.assign) {
+	} else if (bountyRecord.assignTo) {
+		forString = `claimable by user ${bountyRecord.assignTo.discordHandle}`;
+	} else if (bountyRecord.assign) {  // .assign is deprecated
 		const assignedUser = await DiscordUtils.getGuildMemberFromUserId(bountyRecord.assign, bountyRecord.customerId);
 		forString = `claimable by user ${assignedUser ? assignedUser.user.tag : "<missing user>"}`;
 	} else {

--- a/src/app/activity/bounty/Paid.ts
+++ b/src/app/activity/bounty/Paid.ts
@@ -25,6 +25,9 @@ export const paidBounty = async (request: PaidRequest): Promise<void> => {
     await writeDbHandler(request, paidByUser);
 
     const cardMessage = await BountyUtils.canonicalCard(getDbResult.dbBountyResult._id, request.activity);
+
+	// Update bounty with any web compatibility changes or conversions
+	BountyUtils.bountyCleanUp(getDbResult.dbBountyResult._id);
 	
 	const creatorPaidDM = 
         `Thank you for marking your bounty as paid <${cardMessage.url}>\n` +

--- a/src/app/activity/bounty/Publish.ts
+++ b/src/app/activity/bounty/Publish.ts
@@ -29,6 +29,10 @@ export const publishBounty = async (publishRequest: PublishRequest): Promise<any
 	const bountyChannel: TextChannel = dbBountyResult.createdInChannel ? await DiscordUtils.getTextChannelfromChannelId(dbBountyResult.createdInChannel) :
 		await guildMember.client.channels.fetch(dbCustomerResult.bountyChannel) as TextChannel;
 	const bountyMessage: Message = await BountyUtils.canonicalCard(dbBountyResult._id, publishRequest.activity, bountyChannel, guildMember);
+
+	// Update bounty with any web compatibility changes or conversions
+	BountyUtils.bountyCleanUp(dbBountyResult._id);
+
 	await guildMember.send({ content: `Bounty published to \`${(bountyMessage.channel as any).name || bountyChannel.name}\` <${bountyMessage.url}> and the website! <${process.env.BOUNTY_BOARD_URL}${bountyId}>` });
 	Log.info(`bounty published to ${(bountyMessage.channel as any).name || bountyChannel.name}`);
 

--- a/src/app/activity/bounty/Submit.ts
+++ b/src/app/activity/bounty/Submit.ts
@@ -26,6 +26,9 @@ export const submitBounty = async (request: SubmitRequest): Promise<void> => {
 
     const cardMessage = await BountyUtils.canonicalCard(getDbResult.dbBountyResult._id, request.activity);
 
+	// Update bounty with any web compatibility changes or conversions
+	BountyUtils.bountyCleanUp(getDbResult.dbBountyResult._id);
+
 	let creatorSubmitDM = `Please reach out to <@${submittedByUser.user.id}>. They are ready for bounty review <${cardMessage.url}>`
 
 	if (request.url) {

--- a/src/app/auth/commandAuth.ts
+++ b/src/app/auth/commandAuth.ts
@@ -105,7 +105,9 @@ const publish = async (request: PublishRequest): Promise<void> => {
         _id: new mongo.ObjectId(request.bountyId),
     });
 
-    if (dbBountyResult.gate && !(await DiscordUtils.hasAllowListedRole(request.userId, request.guildId, dbBountyResult.gate))) {
+    const gate = (dbBountyResult.gate || (dbBountyResult.gateTo && dbBountyResult.gateTo.map( g => g.discordId)));
+
+    if (gate && !(await DiscordUtils.hasAllowListedRole(request.userId, request.guildId, gate))) {
         throw new AuthorizationError(
             `Thank you for giving bounty commands a try!\n` +
             `It looks like you don't have permission to ${request.activity} this bounty.\n` +
@@ -132,7 +134,8 @@ const publish = async (request: PublishRequest): Promise<void> => {
         }
     }
 
-    if (dbBountyResult.requireApplication && (!dbBountyResult.assign || (request.userId !== dbBountyResult.assign))) {
+    const assignedTo = (dbBountyResult.assign || dbBountyResult.assignTo?.discordId);
+    if (dbBountyResult.requireApplication && (!assignedTo || (request.userId !== assignedTo))) {
         throw new AuthorizationError(
             `Thank you for giving bounty commands a try!\n` +
             'This bounty requires you to apply for it first, and the bounty creator\n' + 
@@ -140,7 +143,7 @@ const publish = async (request: PublishRequest): Promise<void> => {
         )
     }
     
-    if (dbBountyResult.assign && (request.userId !== dbBountyResult.assign)) {
+    if (assignedTo && (request.userId !== assignedTo)) {
         throw new AuthorizationError(
             `Thank you for giving bounty commands a try!\n` +
             `It looks like you don't have permission to ${request.activity} this bounty.\n` +

--- a/src/app/requests/CreateRequest.ts
+++ b/src/app/requests/CreateRequest.ts
@@ -12,8 +12,7 @@ export class CreateRequest extends Request {
     claimLimit: number;
     copies: number;
     gate: string;
-    assign: string;
-    assignedName: string;
+    assign: string; 
     requireApplication: boolean;
     owedTo: string;
     isIOU: boolean;

--- a/src/app/types/bounty/Bounty.ts
+++ b/src/app/types/bounty/Bounty.ts
@@ -1,6 +1,7 @@
 import { Double, Int32, ObjectId } from 'mongodb';
 
 // TODO - *TWE I don't think we need both this and BountyCollection. Settle on one or the other
+// assign and assignedName are deprecated, replaced by assignTo
 export interface Bounty {
 	_id?: ObjectId,
 	season?: string,
@@ -26,6 +27,7 @@ export interface Bounty {
 	submissionNotes?: string,
 	customerId: string,
 	gate?: string[],
+	gateTo?: RoleObject[],
 	evergreen?: boolean,
 	claimLimit?: Int32,
 	isParent?: boolean,
@@ -33,6 +35,7 @@ export interface Bounty {
 	childrenIds?: ObjectId[]
 	assign?: string,
 	assignedName?: string,
+	assignTo?: UserObject,
 	requireApplication?: boolean,
 	applicants?: Applicant[],
 	activityHistory: ClientInteraction[],
@@ -55,8 +58,15 @@ export type MessageInfo = {
 export type Applicant = {
 	discordId: string,
 	discordHandle: string,
+	iconUrl: string,
 	pitch: string,
-}
+};
+
+export type RoleObject = {
+	discordId: string,
+	discordName: string,
+	iconUrl: string,
+};
 
 export type Reward = {
 	currency: string,

--- a/src/app/types/bounty/BountyCollection.ts
+++ b/src/app/types/bounty/BountyCollection.ts
@@ -1,5 +1,6 @@
 import { Collection, Double, Int32, ObjectId } from 'mongodb';
 
+// assign and assignedName are deprecated, replaced by assignTo
 export interface BountyCollection extends Collection {
 	_id: ObjectId,
 	season: string,
@@ -26,6 +27,7 @@ export interface BountyCollection extends Collection {
 	claimantMessage: MessageInfo,
 	customerId: string,
 	gate: string[],
+	gateTo: RoleObject[],
 	evergreen: boolean,
 	claimLimit: Int32,
 	isParent: boolean,
@@ -33,6 +35,7 @@ export interface BountyCollection extends Collection {
 	childrenIds: ObjectId[]
 	assign: string,
 	assignedName: string,
+	assignTo: UserObject,
 	requireApplication: boolean,
 	applicants: Applicant[],
 	activityHistory: ClientInteraction[],
@@ -55,8 +58,15 @@ export type MessageInfo = {
 export type Applicant = {
 	discordId: string,
 	discordHandle: string,
+	iconUrl: string,
 	pitch: string,
-}
+};
+
+export type RoleObject = {
+	discordId: string,
+	discordName: string,
+	iconUrl: string,
+};
 
 export type Reward = {
 	currency: string,

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -250,9 +250,13 @@ const BountyUtils = {
                 title += '\n(Infinite claims available)';
             }
         }
-        if (bountyRecord.assign) {
+        if (bountyRecord.assignTo) {
+            title += `\n(For user ${bountyRecord.assignTo.discordHandle})`
+        } else if (bountyRecord.assign) {  //assign is deprecated, replaced by assignTo
             title += `\n(For user ${bountyRecord.assignedName})`
-        } else if (bountyRecord.gate) {
+        } else if (bountyRecord.gateTo) {
+            title += `\n(For role ${bountyRecord.gateTo[0].discordName})`;  
+        } else if (bountyRecord.gate) {  // deprecated, repalced by gateTo
             const role: Role = await DiscordUtils.getRoleFromRoleId(bountyRecord.gate[0], bountyRecord.customerId);
             title += `\n(For role ${role.name})`;
         } else if (bountyRecord.isIOU) {
@@ -297,11 +301,15 @@ const BountyUtils = {
             { name: 'Deadline', value: BountyUtils.formatDisplayDate(bounty.dueAt), inline: true },
             { name: 'Created by', value: bounty.createdBy.discordHandle.toString(), inline: true }
         ];
-        if (bounty.gate) {
+        if (bounty.gateTo) {
+            fields.push({ name: 'For role', value: bounty.gateTo[0].discordName, inline: false })
+        } else if (bounty.gate) {  // deprecated, replaced by gateTo
             const role = await DiscordUtils.getRoleFromRoleId(bounty.gate[0], bounty.customerId);
             fields.push({ name: 'For role', value: role.name, inline: false })
         }
-        if (bounty.assign) {
+        if (bounty.assignTo) {
+            fields.push({ name: 'For user', value: bounty.assignTo.discordHandle, inline: false })
+        } else if (bounty.assign) {  // assign is deprecated, replaced by assignTo
             const assignedUser = await DiscordUtils.getGuildMemberFromUserId(bounty.assign, bounty.customerId);
             fields.push({ name: 'For user', value: assignedUser.user.tag, inline: false })
         }
@@ -317,7 +325,7 @@ const BountyUtils = {
                 reacts.push('❌');
                 break;
             case BountyStatus.open:
-                if (bounty.requireApplication && (!bounty.assign)) {
+                if (bounty.requireApplication && (!bounty.assign) && (!bounty.assignTo)) {
                     footer = { text: '🙋 - apply | ❌ - delete', };
                     reacts.push('🙋');
                 } else {
@@ -552,7 +560,59 @@ const BountyUtils = {
         });
 
         return customer.lastListMessage;
-    }
+    },
+
+    // bountyCleanUp 
+    //  This is the place to add any db record conversions or other schema or data changes that can be done over time,
+    //  and to add data that the web front end might not have access to.
+    //
+    //  It will be called after each activity that affects a bounty record.
+    //
+    async bountyCleanUp(bountyId: string): Promise<any> {
+        const db: Db = await MongoDbUtils.connect('bountyboard');
+        const bountyCollection = db.collection('bounties');
+        const bounty: BountyCollection = await bountyCollection.findOne({
+            _id: new mongo.ObjectId(bountyId)
+        });
+
+        const customerId = bounty.customerId;
+
+        // If the user avatar URLs are missing, this bounty was probably created on the web. Populate the URLs
+        if (bounty.createdBy && !bounty.createdBy.iconUrl) {
+            bounty.createdBy.iconUrl = (await DiscordUtils.getGuildMemberFromUserId(bounty.createdBy.discordId, customerId)).user.avatarURL();
+        }
+        if (bounty.claimedBy && !bounty.claimedBy.iconUrl) {
+            bounty.claimedBy.iconUrl = (await DiscordUtils.getGuildMemberFromUserId(bounty.claimedBy.discordId, customerId)).user.avatarURL();
+        }
+        if (bounty.submittedBy && !bounty.submittedBy.iconUrl) {
+            bounty.submittedBy.iconUrl = (await DiscordUtils.getGuildMemberFromUserId(bounty.submittedBy.discordId, customerId)).user.avatarURL();
+        }
+        if (bounty.reviewedBy && !bounty.reviewedBy.iconUrl) {
+            bounty.reviewedBy.iconUrl = (await DiscordUtils.getGuildMemberFromUserId(bounty.reviewedBy.discordId, customerId)).user.avatarURL();
+        }
+        if (bounty.applicants) {
+            bounty.applicants.forEach( async (a, i) => {
+                if (!a.iconUrl) {
+                    bounty.applicants[i].iconUrl = (await DiscordUtils.getGuildMemberFromUserId(a.discordId, customerId)).user.avatarURL();
+                }
+            })
+        }
+
+        // If assignTo is missing, create it from the deprecated assign item
+        if (bounty.assign && !bounty.assignTo) {
+            const assignedUser = await DiscordUtils.getGuildMemberFromUserId(bounty.assign, customerId)
+            bounty.assignTo = {discordId: assignedUser.user.id, discordHandle: assignedUser.user.tag, iconUrl: assignedUser.user.avatarURL()};
+        }
+
+        // If gateTo is missing, create it from the deprecated gate item
+        if (bounty.gate && !bounty.gateTo) {
+            const gatedTo = await DiscordUtils.getRoleFromRoleId(bounty.gate[0], customerId)
+            bounty.gateTo = [{discordId: gatedTo.id, discordName: gatedTo.name, iconUrl: gatedTo.iconURL() }];
+        }
+
+        await bountyCollection.replaceOne({ _id: new mongo.ObjectId(bounty._id) }, bounty);
+    },
+
 }
 
 export default BountyUtils;


### PR DESCRIPTION
Changes on the bot to clean up data on bounties coming from the web, and a couple schema changes for consistency:

- assign and assignedName are replaced by the object assignTo that matches the user object used for other user items
- gate is replaced by gateTo which hold Discord data the web needs to display the role
- BountyUtils.bountyCleanup is called after every activity that modifies bounties. It: 
-- Makes the above schema changes to the data (the code base was changed to support both for now)
-- It adds missing avatar URLs for users on bounties that came from the web. The client sync will route through this routine.