### PR TITLE
Feature/gate on multi claimant and require application

### DIFF
--- a/src/app/activity/bounty/List.ts
+++ b/src/app/activity/bounty/List.ts
@@ -44,7 +44,13 @@ export const listBounty = async (request: ListRequest): Promise<any> => {
 		openTitle = "Applied For"
 		break;
 	default: 
-		dbRecords = bountyCollection.find({ $or: [ { status: BountyStatus.open } , { status: BountyStatus.in_progress }, { status: BountyStatus.in_review } ], isIOU: { $ne: true }, 'customerId': request.guildId }).sort({ status: -1, createdAt: -1 });
+		// Make sure "in_review" bounties don't exhaust the list limit before "in_progress" are fetched
+		const statusOrder = [ BountyStatus.open, BountyStatus.in_progress, BountyStatus.in_review ];
+		const m = { "$match" : { "status" : { "$in" : statusOrder } } };
+    	const a = { "$addFields" : { "__order" : { "$indexOfArray" : [ statusOrder, "$status" ] } } };
+    	const s = { "$sort" : { "__order" : 1, "createdAt" : -1 } };
+    	dbRecords = bountyCollection.aggregate( [ m, a, s ] );
+		// dbRecords = bountyCollection.find({ $or: [ { status: BountyStatus.open } , { status: BountyStatus.in_progress }, { status: BountyStatus.in_review } ], isIOU: { $ne: true }, 'customerId': request.guildId }).sort({ status: -1, createdAt: -1 });
 		listTitle =  "💰 Active Bounties";
 	}
 
@@ -152,11 +158,11 @@ export const generateBountyFieldSegment = async (bountyRecord: BountyCollection,
 		let claimedByMeMetadata = getClaimedByMeMetadata(bountyRecord, listType);
 		forString = claimedByMeMetadata ?  claimedByMeMetadata : `claimed by @${bountyRecord.claimedBy.discordHandle}`;
 	} else {
-	  if (bountyRecord.gate) {
-			const role = await DiscordUtils.getRoleFromRoleId(bountyRecord.gate[0], bountyRecord.customerId);
+	  if (bountyRecord.gate || bountyRecord.gateTo) {
+			const role = await DiscordUtils.getRoleFromRoleId(bountyRecord.gate ? bountyRecord.gate[0] : bountyRecord.gateTo[0].discordId, bountyRecord.customerId);
 			forString = `claimable by role ${role ? role.name : "<missing role>"}`;
-		} else if (bountyRecord.assign) {
-			const assignedUser = await DiscordUtils.getGuildMemberFromUserId(bountyRecord.assign, bountyRecord.customerId);
+		} else if (bountyRecord.assign || bountyRecord.assignTo) {
+			const assignedUser = await DiscordUtils.getGuildMemberFromUserId(bountyRecord.assign || bountyRecord.assignTo.discordId, bountyRecord.customerId);
 			forString = `claimable by user ${assignedUser ? assignedUser.user.tag : "<missing user>"}`;
 		} else {
 			forString = 'claimable by anyone';

--- a/src/app/activity/bounty/List.ts
+++ b/src/app/activity/bounty/List.ts
@@ -47,9 +47,9 @@ export const listBounty = async (request: ListRequest): Promise<any> => {
 		// Make sure "in_review" bounties don't exhaust the list limit before "in_progress" are fetched
 		const statusOrder = [ BountyStatus.open, BountyStatus.in_progress, BountyStatus.in_review ];
 		const m = { "$match" : { "status" : { "$in" : statusOrder } } };
-    	const a = { "$addFields" : { "__order" : { "$indexOfArray" : [ statusOrder, "$status" ] } } };
-    	const s = { "$sort" : { "__order" : 1, "createdAt" : -1 } };
-    	dbRecords = bountyCollection.aggregate( [ m, a, s ] );
+		const a = { "$addFields" : { "__order" : { "$indexOfArray" : [ statusOrder, "$status" ] } } };
+		const s = { "$sort" : { "__order" : 1, "createdAt" : -1 } };
+		dbRecords = bountyCollection.aggregate( [ m, a, s ] );
 		// dbRecords = bountyCollection.find({ $or: [ { status: BountyStatus.open } , { status: BountyStatus.in_progress }, { status: BountyStatus.in_review } ], isIOU: { $ne: true }, 'customerId': request.guildId }).sort({ status: -1, createdAt: -1 });
 		listTitle =  "💰 Active Bounties";
 	}

--- a/src/app/auth/commandAuth.ts
+++ b/src/app/auth/commandAuth.ts
@@ -188,6 +188,17 @@ const apply = async (request: ApplyRequest): Promise<void> => {
             `Please reach out to your favorite bounty board representative with any questions!` 
         );
     }
+
+    const gate = (dbBountyResult.gateTo && dbBountyResult.gateTo.map( g => g.discordId));
+
+    if (gate && !(await DiscordUtils.hasAllowListedRole(request.userId, request.guildId, gate))) {
+        throw new AuthorizationError(
+            `Thank you for giving bounty commands a try!\n` +
+            `It looks like you don't have permission to apply for this bounty.\n` +
+            `The creator of this bounty gated it to specific role holders. Check the "for-role" value of the bounty to see which role you would need to apply for it.`
+        );
+    }
+
 }
 
 const assign = async (request: AssignRequest): Promise<void> => {

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -102,9 +102,9 @@ const BountyUtils = {
         }
     },
 
-    validateEvergreen(evergreen: boolean, claimLimit: number, gateOrAssign: boolean) {
-        if (evergreen && gateOrAssign) {
-            throw new ValidationError('Cannot use for-role or for-user with multiple-claimant bounties');
+    validateEvergreen(evergreen: boolean, claimLimit: number, assign: boolean) {
+        if (evergreen && assign) {
+            throw new ValidationError('Cannot use for-user with multiple-claimant bounties');
         }
         if (claimLimit !== undefined && (claimLimit < 0 || claimLimit > 100)) {
             throw new ValidationError('claimants should be from 0 (meaning infinite) to 100');
@@ -116,9 +116,8 @@ const BountyUtils = {
             throw new ValidationError('Cannot require applications on multi-claimant bounties.');
         }
 
-        // TODO Allow requireApplications on gated bounties
-        if (request.requireApplication && (request.assign || request.gate)) {
-            throw new ValidationError('Cannot require applications on bounties gated to users or roles.');
+        if (request.requireApplication && request.assign) {
+            throw new ValidationError('Cannot require applications on bounties assigned to a user.');
         }
     },
 

--- a/src/app/validation/commandValidation.ts
+++ b/src/app/validation/commandValidation.ts
@@ -75,7 +75,7 @@ const create = async (request: CreateRequest): Promise<void> => {
 
     BountyUtils.validateReward(request.reward);
 
-    BountyUtils.validateEvergreen(request.evergreen, request.claimLimit, !!(request.assign || request.gate));
+    BountyUtils.validateEvergreen(request.evergreen, request.claimLimit, !!request.assign);
 
     BountyUtils.validateRequireApplications(request);
 


### PR DESCRIPTION
Several changes:

1) You can now gate multi-claimant and require-application bounties to a role. Asana task https://app.asana.com/0/1201944923757693/1202727660511446/f
2) Fixes a List bug where the "claimable by" was not correct for new bounties. Fixes #55 
3) Fixes a List bug where InReview bounties were sorted before InProgress bounties during the fetch (the list display sort is independent of this). This could cause the list fetch limit to be hit during the InReview fetch, making it look in the display like there were no InProgress bounties even though there were.