### PR TITLE
Fix claimed-by-me list when paid status is missing

### DIFF
--- a/src/app/activity/bounty/List.ts
+++ b/src/app/activity/bounty/List.ts
@@ -9,6 +9,7 @@ import { CustomerCollection } from '../../types/bounty/CustomerCollection';
 import { BountyStatus } from '../../constants/bountyStatus';
 import { ConnectionVisibility } from 'discord-api-types';
 import DMPermissionError from '../../errors/DMPermissionError';
+import { PaidStatus } from '../../constants/paidStatus';
 
 const TOTAL_BOUNTY_LIMIT = 15;
 const BOUNTY_SEGMENT_LIMIT = 5;
@@ -185,7 +186,7 @@ const getClaimedByMeMetadata = (record: BountyCollection, listType: string) => {
 	
 	if (listType === 'CLAIMED_BY_ME') {
 		  if (record.status === BountyStatus.complete) {
-				text = `payment is ${record.paidStatus.toUpperCase()}`;
+				text = `payment is ${(record.paidStatus ? record.paidStatus : PaidStatus.unpaid).toUpperCase()}`;
 			} else if (record.status === BountyStatus.in_progress || record.status === BountyStatus.in_review) {
 				text = `is due on ${new Date (record.dueAt).toLocaleDateString()}`;
 			}


### PR DESCRIPTION
If you are doing a CLAIMED BY ME list, and you have an old completed bounty with no Paid Status that will appear on the list (i.e. doesn't drop off the bottom because of too many bounties), the list would error out because we are trying to toUpperCase() the missing status.

This fixes that. Note that more-recently-created bounties have Paid Status set to UNPAID when they are created.