### PR TITLE
Modals on the bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ build
 
 # jest-mongodb output
 globalConfig.json
+.vscode/settings.json

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@logdna/logger": "^2.6.0",
     "@types/mongodb": "^3.6.20",
-    "discord.js": "^13.3.1",
+    "discord.js": "^13.7.1",
     "dotenv": "^10.0.0",
     "mongodb": "^3.6.9",
     "nodemon": "^2.0.15",

--- a/src/app/activity/bounty/Apply.ts
+++ b/src/app/activity/bounty/Apply.ts
@@ -67,7 +67,6 @@ export const applyBounty = async (request: ApplyRequest): Promise<any> => {
         try {
             await request.buttonInteraction.showModal(Object.assign(modal as unknown as ModalOptions, {customId: uuid}));
         } catch(e) {
-            console.log(e.message)
             return;
         }
         const submittedInteraction = (await request.buttonInteraction.awaitModalSubmit({

--- a/src/app/activity/bounty/Apply.ts
+++ b/src/app/activity/bounty/Apply.ts
@@ -1,4 +1,4 @@
-import { GuildMember, Message, DMChannel, AwaitMessagesOptions } from 'discord.js';
+import { GuildMember, ModalSubmitInteraction, ModalOptions, ButtonInteraction } from 'discord.js';
 import { ApplyRequest } from '../../requests/ApplyRequest';
 import { BountyCollection } from '../../types/bounty/BountyCollection';
 import DiscordUtils from '../../utils/DiscordUtils';
@@ -8,36 +8,92 @@ import mongo, { Db, UpdateWriteOpResult } from 'mongodb';
 import MongoDbUtils from '../../utils/MongoDbUtils';
 import { CustomerCollection } from '../../types/bounty/CustomerCollection';
 import BountyUtils from '../../utils/BountyUtils';
-import DMPermissionError from '../../errors/DMPermissionError';
+import { ModalOptions as scModalOptions, ComponentType, ModalInteractionContext, TextInputStyle } from 'slash-create';
+import RuntimeError from '../../errors/RuntimeError';
 
 export const applyBounty = async (request: ApplyRequest): Promise<any> => {
     Log.debug('In Apply activity');
-    const applyingUser = await DiscordUtils.getGuildMemberFromUserId(request.userId, request.guildId);
-    Log.info(`${request.bountyId} bounty applied for by ${applyingUser.user.tag}`);
-    
-    const pitchMessageText = `Hello @${applyingUser.displayName}!\n` +
-        `Please respond to the following within 5 minutes.\n` +
-        `Please tell the bounty creator why you should be chosen to claim this bounty (your pitch)`;
-    const pitchMessage: Message = await applyingUser.send({ content: pitchMessageText }).catch(() => { throw new DMPermissionError(pitchMessageText) });
-    const dmChannel: DMChannel = await pitchMessage.channel.fetch() as DMChannel;
-    const replyOptions: AwaitMessagesOptions = {
-        max: 1,
-        // time is in ms
-        time: 300000,
-        errors: ['time'],
+
+    // Different modal data types and calls in slash commands vs. button interactions
+    const fromSlash = !!request.commandContext;
+
+    const modal = {
+        title: 'What\'s your pitch?',
+        components: [
+        {
+            type: (fromSlash ? ComponentType.ACTION_ROW : "ACTION_ROW"),
+            components: [
+            {
+                type: (fromSlash ? ComponentType.TEXT_INPUT : "TEXT_INPUT"),
+                label: 'Pitch',
+                style: (fromSlash ? TextInputStyle.PARAGRAPH: "PARAGRAPH"),
+                max_length: 4000,
+                custom_id: 'pitch',
+                placeholder: 'Why should this bounty be assigned to you?'
+            }]
+        }]
     };
 
-    const gotoDMMessage = 'Go to your DMs to finish appplying for the bounty...';
-    await DiscordUtils.activityResponse(request.commandContext, request.buttonInteraction, gotoDMMessage);
+    // Callback for the slash version
+    const modalCallback = async (modalContext: ModalInteractionContext, request: any) => {
 
-    const pitch = await DiscordUtils.awaitUserDM(dmChannel, replyOptions);
-    try {
-        BountyUtils.validatePitch(pitch);
-    } catch (e) {
-        if (e instanceof ValidationError) {
-            applyingUser.send({ content: `<@${applyingUser.user.id}>\n` + e.message })
+        await modalContext.defer(true);
+        const pitch = modalContext.values.pitch;
+        try {
+            BountyUtils.validatePitch(pitch);
+        } catch (e) {
+            if (e instanceof ValidationError) {
+                await modalContext.send(e.message);
+                return;
+            } 
+            throw new RuntimeError(e);               
         }
+
+        await modalContext.send('Pitch accepted');
+
+        await finishApply(request, pitch);
+    };
+
+    // Call the modal. For slash command, call the callback. For button interaction, wait for submit and then finish. 
+
+    if (fromSlash) {
+        await request.commandContext.sendModal(modal as scModalOptions ,async (mctx) => { await modalCallback(mctx, request) });
+        return;
+    } else {
+        try {
+            await request.buttonInteraction.showModal(Object.assign(modal as unknown as ModalOptions, {customId: 'pitch'}));
+        } catch(e) {
+            console.log(e.message)
+            return;
+        }
+        const submittedInteraction = (await request.buttonInteraction.awaitModalSubmit({
+            time: 60000,
+            filter: i => i.user.id === request.userId,
+            }).catch(e => {
+            console.log(e.message)
+            return;
+            })) as ModalSubmitInteraction;
+        const pitch = submittedInteraction.components[0].components[0].value;
+        try {
+            BountyUtils.validatePitch(pitch);
+        } catch (e) {
+            if (e instanceof ValidationError) {
+                await submittedInteraction.reply({content: e.message, ephemeral: true});
+                return;
+            } 
+            throw new RuntimeError(e);               
+        }
+
+        // We have a new interaction, use that for the request reponse.
+        request.buttonInteraction = submittedInteraction as unknown as ButtonInteraction;
+
+        await finishApply(request, pitch);
     }
+}
+
+export const finishApply = async (request: ApplyRequest, pitch: string) => {
+    const applyingUser = await DiscordUtils.getGuildMemberFromUserId(request.userId, request.guildId);
+    Log.info(`${request.bountyId} bounty applied for by ${applyingUser.user.tag}`);
     
     let getDbResult: {dbBountyResult: BountyCollection, bountyChannel: string} = await getDbHandler(request);
 
@@ -53,7 +109,6 @@ export const applyBounty = async (request: ApplyRequest): Promise<any> => {
     await DiscordUtils.activityNotification(creatorDM, createdByUser, cardMessage.url);
     const activityMessage = `<@${applyingUser.user.id}>, You have applied for this bounty! Reach out to <@${createdByUser.id}> with any questions.`;
     await DiscordUtils.activityResponse(request.commandContext, request.buttonInteraction, activityMessage, cardMessage.url);
-    await applyingUser.send({ content: activityMessage })
     return;
 };
 

--- a/src/app/activity/bounty/Claim.ts
+++ b/src/app/activity/bounty/Claim.ts
@@ -1,4 +1,4 @@
-import { GuildMember, Message, DMChannel } from 'discord.js';
+import { GuildMember } from 'discord.js';
 import { ClaimRequest } from '../../requests/ClaimRequest';
 import { BountyCollection } from '../../types/bounty/BountyCollection';
 import DiscordUtils from '../../utils/DiscordUtils';
@@ -10,11 +10,8 @@ import { BountyStatus } from '../../constants/bountyStatus';
 import BountyUtils from '../../utils/BountyUtils';
 import { Activities } from '../../constants/activities';
 import { Clients } from '../../constants/clients';
-import { UserCollection } from '../../types/user/UserCollection';
 import ValidationError from '../../errors/ValidationError';
 import TimeoutError from '../../errors/TimeoutError';
-import DMPermissionError from '../../errors/DMPermissionError';
-import { ModalInteractionContext } from 'slash-create';
 
 export const claimBounty = async (request: ClaimRequest): Promise<any> => {
     Log.debug('In Claim activity');

--- a/src/app/activity/bounty/Claim.ts
+++ b/src/app/activity/bounty/Claim.ts
@@ -19,7 +19,7 @@ import RuntimeError from '../../errors/RuntimeError';
 export const claimBounty = async (request: ClaimRequest): Promise<any> => {
     Log.debug('In Claim activity');
     
-    if (! (await BountyUtils.userWalletRegistered(request.userId)) || true) {
+    if (! (await BountyUtils.userWalletRegistered(request.userId)) ) {
         console.log("Before wallet");
         const upsertWalletRequest = new UpsertUserWalletRequest({
             userDiscordId: request.userId,

--- a/src/app/activity/bounty/Claim.ts
+++ b/src/app/activity/bounty/Claim.ts
@@ -39,8 +39,7 @@ export const claimBounty = async (request: ClaimRequest): Promise<any> => {
                 return;
             }
             if (e instanceof ModalTimeoutError) {
-                await DiscordUtils.activityResponse(request.commandContext, request.buttonInteraction, `Unable to complete this operation - form timeout.\n` +
-                'Please try entering your wallet address with the command `/register-wallet` and then try claiming the bounty again.\n');
+                await DiscordUtils.activityResponse(request.commandContext, request.buttonInteraction, `Unable to complete this operation - form timeout.`);
                 return;
             }
             throw new RuntimeError(e);               

--- a/src/app/activity/bounty/Claim.ts
+++ b/src/app/activity/bounty/Claim.ts
@@ -15,6 +15,7 @@ import TimeoutError from '../../errors/TimeoutError';
 import { UpsertUserWalletRequest } from '../../requests/UpsertUserWalletRequest';
 import { handler } from './Handler';
 import RuntimeError from '../../errors/RuntimeError';
+import ModalTimeoutError from '../../errors/ModalTimeoutError';
 
 export const claimBounty = async (request: ClaimRequest): Promise<any> => {
     Log.debug('In Claim activity');
@@ -36,6 +37,12 @@ export const claimBounty = async (request: ClaimRequest): Promise<any> => {
             if (e instanceof ValidationError) {
                 console.log("Reply 1: activityResponse");
                 await DiscordUtils.activityResponse(request.commandContext, request.buttonInteraction, `Unable to complete this operation.\n` +
+                'Please try entering your wallet address with the command `/register-wallet` and then try claiming the bounty again.\n');
+                return;
+            }
+            if (e instanceof ModalTimeoutError) {
+                console.log("Reply 50: activityResponse");
+                await DiscordUtils.activityResponse(request.commandContext, request.buttonInteraction, `Unable to complete this operation - form timeout.\n` +
                 'Please try entering your wallet address with the command `/register-wallet` and then try claiming the bounty again.\n');
                 return;
             }

--- a/src/app/activity/bounty/Create.ts
+++ b/src/app/activity/bounty/Create.ts
@@ -135,7 +135,7 @@ export const finishCreate = async (createRequest: CreateRequest, description: st
 
     Log.info(`user ${guildMember.user.tag} inserted bounty into db`);
 
-    const cardMessage = await BountyUtils.canonicalCard(newBounty._id, createRequest.activity, await DiscordUtils.getTextChannelfromChannelId(newBounty.createdInChannel), guildMember, modalContext);
+    const cardMessage = await BountyUtils.canonicalCard(newBounty._id, createRequest.activity, await DiscordUtils.getTextChannelfromChannelId(newBounty.createdInChannel), guildMember);
 
     if (createRequest.isIOU) {
         // await createRequest.commandContext.sendFollowUp({ content: "Your IOU was created." } , { ephemeral: true });

--- a/src/app/activity/bounty/Create.ts
+++ b/src/app/activity/bounty/Create.ts
@@ -58,7 +58,8 @@ export const createBounty = async (createRequest: CreateRequest): Promise<any> =
                     label: 'Due Date',
                     style: TextInputStyle.SHORT,
                     custom_id: 'dueAt',
-                    placeholder: 'yyyy-mm-dd, or \'no\' or \'skip\' for 3 months from today'
+                    placeholder: 'yyyy-mm-dd, or leave blank for 3 months from today',
+                    required: false
                   }
                 ]
               }
@@ -96,7 +97,9 @@ export const modalCallback = async (modalContext: ModalInteractionContext, creat
 
     const dueAt = modalContext.values.dueAt;
     let convertedDueDateFromMessage: Date;
-    if (!(dueAt.toLowerCase() === 'no' || dueAt.toLowerCase() === 'skip')) {
+    if (!dueAt){
+        convertedDueDateFromMessage = BountyUtils.threeMonthsFromNow();
+    } else if (!(dueAt.toLowerCase() === 'no' || dueAt.toLowerCase() === 'skip')) {
         try {
             convertedDueDateFromMessage = BountyUtils.validateDate(dueAt);
         } catch (e) {
@@ -104,8 +107,6 @@ export const modalCallback = async (modalContext: ModalInteractionContext, creat
             await modalContext.send({ content: 'Please try `UTC` date in format `yyyy-mm-dd`, i.e 2021-08-15' });
             return;
         }
-    } else if (dueAt.toLowerCase() === 'no' || dueAt.toLowerCase() === 'skip') {
-        convertedDueDateFromMessage = BountyUtils.threeMonthsFromNow();
     }
 
     if (convertedDueDateFromMessage.toString() === 'Invalid Date') {
@@ -217,7 +218,7 @@ export const generateBountyRecord = async (
     let scale = reward.split('.')[1]?.length;
     scale = (scale != null) ? scale : 0;
     const currentDate = (new Date()).toISOString();
-    let status = BountyStatus.draft;
+    let status = BountyStatus.open;
     if (createRequest.isIOU) {
         status = BountyStatus.complete;
     }

--- a/src/app/activity/bounty/Create.ts
+++ b/src/app/activity/bounty/Create.ts
@@ -144,7 +144,7 @@ export const finishCreate = async (createRequest: CreateRequest, description: st
         const IOUContent = `<@${owedTo.id}> An IOU was created for you by <@${guildMember.user.id}>: ${cardMessage.url}`;
         await owedTo.send({ content: IOUContent }).catch(() => { throw new DMPermissionError(IOUContent) });
 
-        if (!(await BountyUtils.isUserWalletRegistered(owedTo.id))) {
+        if (!(await BountyUtils.userWalletRegistered(owedTo.id))) {
             // Note: ephemeral messagees are only visible to the user who kicked off the interaction,
             // so we can not send an ephemeral message to the owedTo user to check DMs
 
@@ -165,7 +165,7 @@ export const finishCreate = async (createRequest: CreateRequest, description: st
                 if (e instanceof TimeoutError || e instanceof ValidationError) {
                     await owedTo.send(
                         `Unable to complete this operation due to timeout or incorrect wallet addresses.\n` +
-                        'Please try entering your wallet address with the slash command `/register wallet`.\n\n' +
+                        'Please try entering your wallet address with the slash command `/register-wallet`.\n\n' +
                         `Return to Bounty list: ${(await BountyUtils.getLatestCustomerList(createRequest.guildId))}`
                     );
                     await createRequest.commandContext.editOriginal({

--- a/src/app/activity/bounty/List.ts
+++ b/src/app/activity/bounty/List.ts
@@ -7,7 +7,6 @@ import DiscordUtils from '../../utils/DiscordUtils';
 import { ListRequest } from '../../requests/ListRequest';
 import { CustomerCollection } from '../../types/bounty/CustomerCollection';
 import { BountyStatus } from '../../constants/bountyStatus';
-import { ConnectionVisibility } from 'discord-api-types';
 import DMPermissionError from '../../errors/DMPermissionError';
 import { PaidStatus } from '../../constants/paidStatus';
 

--- a/src/app/activity/roles/CustomerRoles.ts
+++ b/src/app/activity/roles/CustomerRoles.ts
@@ -1,4 +1,4 @@
-import { Snowflake } from "discord-api-types";
+import { Snowflake } from "discord-api-types/v9";
 import { Collection, Role } from "discord.js";
 import { Db, UpdateWriteOpResult } from "mongodb";
 import ValidationError from "../../errors/ValidationError";

--- a/src/app/activity/user/RegisterWallet.ts
+++ b/src/app/activity/user/RegisterWallet.ts
@@ -3,12 +3,145 @@ import { UpsertUserWalletRequest } from "../../requests/UpsertUserWalletRequest"
 import { UserCollection } from "../../types/user/UserCollection";
 import MongoDbUtils from "../../utils/MongoDbUtils";
 import Log from "../../utils/Log";
+import BountyUtils from "../../utils/BountyUtils";
+import DiscordUtils from "../../utils/DiscordUtils";
+import { ButtonInteraction, ModalOptions, ModalSubmitInteraction } from "discord.js";
+import { ComponentType, TextInputStyle, ModalInteractionContext, ModalOptions as scModalOptions, CommandContext } from "slash-create";
+import RuntimeError from "../../errors/RuntimeError";
+import ValidationError from "../../errors/ValidationError";
+import WalletUtils, { ADDRESS_DELETE_REGEX } from "../../utils/WalletUtils";
 
 export const upsertUserWallet = async (request: UpsertUserWalletRequest): Promise<any> => {
-    return await dbHandler(request);
+
+    // If an address came with the request, it was already validated, just store it and respond.
+    if (request.address) {
+        await dbHandler(request);
+        await finishRegister(request);
+        return;
+    }
+    
+    // Different modal data types and calls in slash commands vs. button interactions
+    const fromSlash = !!request.commandContext;
+    console.log(`fromSlash ${fromSlash}`);
+    console.log(`commandContext ${request.commandContext}`);
+    const current_address = await BountyUtils.userWalletRegistered(request.userDiscordId);
+    console.log(`Current address ${current_address}`);
+
+    const modal = {
+        title: 'Wallet Address',
+        components: [
+        {
+            type: (fromSlash ? ComponentType.ACTION_ROW : "ACTION_ROW"),
+            components: [
+            {
+                type: (fromSlash ? ComponentType.TEXT_INPUT : "TEXT_INPUT"),
+                label: 'Wallet Address',
+                style: (fromSlash ? TextInputStyle.PARAGRAPH: "PARAGRAPH"),
+                require: true,
+                max_length: 100,
+                custom_id: 'wallet_address',
+                placeholder: 'Enter your wallet address so you can be paid. Enter DELETE to remove your registered address.',
+                value: current_address ? current_address : ""
+            }]
+        }]
+    };
+
+    const walletRegister = async (request: UpsertUserWalletRequest, context: ModalInteractionContext | ModalSubmitInteraction) => {
+
+        try {
+            WalletUtils.validateEthereumWalletAddress(request.address);
+        } catch (e) {
+            if (e instanceof ValidationError) {
+                if (context instanceof ModalInteractionContext) {
+                    await context.send(e.message);
+                } else {
+                    await context.reply({content: e.message, ephemeral: true});
+                }
+                return;
+            } 
+            throw new RuntimeError(e);               
+        }
+        if (context instanceof ModalInteractionContext) {
+            request.commandContext = context as unknown as CommandContext;
+        } else {
+            request.buttonInteraction = context as unknown as ButtonInteraction;
+        }
+        
+        await dbHandler(request);
+        await finishRegister(request);
+
+        if (request.callBack) {
+            await request.callBack(request);
+            return;
+        }
+
+        if (context instanceof ModalInteractionContext) {
+            await context.send('Wallet address updated');
+        } else {
+            try {
+                await context.user.send('Wallet address updated');
+            } catch (e) {
+                Log.debug(`Couldn't sent wallet confirm to @<${context.user}>`);
+            }
+        }
+
+        return;
+
+    }
+
+    // Callback for the slash version
+    const modalCallback = async (modalContext: ModalInteractionContext, request: UpsertUserWalletRequest) => {
+        console.log("In modalCallback");
+        await modalContext.defer(true);
+        request.address = modalContext.values.wallet_address;
+        await walletRegister(request, modalContext);
+    };
+
+    // Call the modal. For slash command, call the callback. For button interaction, wait for submit and return. 
+
+    if (fromSlash) {
+        try {
+            await request.commandContext.sendModal(modal as unknown as scModalOptions,async (mctx) => { await modalCallback(mctx, request) });
+        } catch(e) {
+            Log.error(e.message);
+            throw new RuntimeError(e);
+        }
+        return;
+    } else {
+        try {
+            await request.buttonInteraction.showModal(Object.assign(modal, {customId: 'wallet_address'}) as unknown as ModalOptions);
+        } catch(e) {
+            Log.error(e.message);
+            throw new RuntimeError(e);
+        }
+        console.log("After showModal");
+        const submittedInteraction = await request.buttonInteraction.awaitModalSubmit({
+            time: 60000,
+            filter: i => i.user.id === request.userDiscordId,
+            }).catch(e => {
+            Log.error(e.message);            throw new RuntimeError(e);
+            });
+        request.address = submittedInteraction.components[0].components[0].value;
+        await walletRegister(request, submittedInteraction);
+    }
+    
+}
+
+export const finishRegister = async (request: UpsertUserWalletRequest) => {
+    console.log("In finishRegister");
+    if (ADDRESS_DELETE_REGEX.test(request.address)) {
+        await DiscordUtils.activityResponse(request.commandContext, request.buttonInteraction, "Your wallet address has been deleted.");
+      
+    } else {
+        const activityMessage = `<@${request.userDiscordId}>, your wallet address has been registered as ${request.address}.\n`+
+                                `You can change it by using the /register-wallet command.`;
+        const etherscanUrl = `https://etherscan.io/address/${request.address}`;
+        await DiscordUtils.activityResponse(request.commandContext, request.buttonInteraction, activityMessage, etherscanUrl, "View on Etherscan");
+    }
 }
 
 const dbHandler = async (request: UpsertUserWalletRequest): Promise<void> => {
+    console.log("In dbHandler");
     const db: Db = await MongoDbUtils.connect('bountyboard');
     const userCollection = db.collection('user');
 
@@ -22,11 +155,19 @@ const dbHandler = async (request: UpsertUserWalletRequest): Promise<void> => {
         })
     }
 
-	const writeResult: UpdateWriteOpResult = await userCollection.updateOne({userDiscordId: request.userDiscordId }, {
-		$set: {
-			walletAddress: request.address,
-		},
-	});
+	const writeResult: UpdateWriteOpResult = await userCollection.updateOne({userDiscordId: request.userDiscordId}, 
+        ADDRESS_DELETE_REGEX.test(request.address) ? 
+            {
+                $set: {
+                    walletAddress: request.address,
+                },
+            } :
+            {
+                $unset: {
+                    walletAddress: "",
+                },
+            }
+        );
 
     if (writeResult.result.ok !== 1) {
         Log.error(`Write result did not execute correctly`);

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -101,6 +101,8 @@ changeStream.on("change", async next => {
 		changeEvent.fullDocument = upsertedBountyRecord;
 	}
 
+	console.log(`Client Sync Event: ${changeEvent.operationType}`);
+
 	ClientSync({ changeStreamEvent: changeEvent });
 	});
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -101,8 +101,6 @@ changeStream.on("change", async next => {
 		changeEvent.fullDocument = upsertedBountyRecord;
 	}
 
-	console.log(`Client Sync Event: ${changeEvent.operationType}`);
-
 	ClientSync({ changeStreamEvent: changeEvent });
 	});
 }

--- a/src/app/clientSync/ClientSync.ts
+++ b/src/app/clientSync/ClientSync.ts
@@ -21,10 +21,13 @@ import Log, { LogUtils } from "../utils/Log";
  * @returns void promise
  */
 export const ClientSync = async (args: {changeStreamEvent: ChangeStreamEvent}): Promise<void> => {
-    // if OperationType is insert, updatedFields will be invalid
+    // if OperationType is insert, updatedFields will be invalid, so they won't get filtered
+    // if OperationType is update, filter out if no new activity in the history and the paid status didn't change
+    // if OperationType is replace, it's currently only our Bounty Fix cleanup on the bot side that does that, so filter it
     let filterEvent = (
-        "update" === args.changeStreamEvent.operationType && 
-        !args.changeStreamEvent.updateDescription.updatedFields.activityHistory
+        ("update" === args.changeStreamEvent.operationType && 
+        !args.changeStreamEvent.updateDescription.updatedFields.activityHistory && !args.changeStreamEvent.updateDescription.updatedFields.paidStatus) ||
+        ("replace" === args.changeStreamEvent.operationType)
     );
     
     if (filterEvent) {

--- a/src/app/clientSync/ClientSync.ts
+++ b/src/app/clientSync/ClientSync.ts
@@ -21,15 +21,12 @@ import Log, { LogUtils } from "../utils/Log";
  * @returns void promise
  */
 export const ClientSync = async (args: {changeStreamEvent: ChangeStreamEvent}): Promise<void> => {
-    // if OperationType is insert, updatedFields will be invalid, so they won't get filtered
-    // if OperationType is update, filter out if no new activity in the history and the paid status didn't change
-    // if OperationType is replace, it's currently only our Bounty Fix cleanup on the bot side that does that, so filter it
-    let filterEvent = (
-        ("update" === args.changeStreamEvent.operationType && 
-        !args.changeStreamEvent.updateDescription.updatedFields.activityHistory && !args.changeStreamEvent.updateDescription.updatedFields.paidStatus) ||
-        ("replace" === args.changeStreamEvent.operationType)
+     // if OperationType is insert, updatedFields will be invalid
+     let filterEvent = (
+        "update" === args.changeStreamEvent.operationType && 
+        !args.changeStreamEvent.updateDescription.updatedFields.activityHistory
     );
-    
+   
     if (filterEvent) {
         return;
     }

--- a/src/app/commands/bounty/Wallet.ts
+++ b/src/app/commands/bounty/Wallet.ts
@@ -9,11 +9,9 @@ import { handler } from '../../activity/bounty/Handler';
 import ValidationError from '../../errors/ValidationError';
 import AuthorizationError from '../../errors/AuthorizationError';
 import Log, { LogUtils } from '../../utils/Log';
-import { Request } from '../../requests/Request';
 import { guildIds } from '../../constants/customerIds';
 import { Activities } from '../../constants/activities';
 import { UpsertUserWalletRequest } from '../../requests/UpsertUserWalletRequest';
-import DiscordUtils from '../../utils/DiscordUtils';
 
 export default class Wallet extends SlashCommand {
     constructor(creator: SlashCreator) {
@@ -27,7 +25,7 @@ export default class Wallet extends SlashCommand {
                         name: 'eth-wallet-address',
                         type: CommandOptionType.STRING,
                         description: 'Enter your ethereum wallet address',
-                        required: true,
+                        required: false,
                     },
                 ],
             throttling: {
@@ -59,7 +57,10 @@ export default class Wallet extends SlashCommand {
 
         const request = new UpsertUserWalletRequest({
             userDiscordId: commandContext.user.id,
-            address: commandContext.options['eth-wallet-address']
+            address: commandContext.options['eth-wallet-address'],
+            commandContext: commandContext,
+            buttonInteraction: null,
+            callBack: null
 
         })
         //const { guildMember } = await DiscordUtils.getGuildAndMember(commandContext.guildID, commandContext.user.id);
@@ -83,7 +84,7 @@ export default class Wallet extends SlashCommand {
             }
         }
 
-        return await commandContext.send(`<@${request.userDiscordId}>, registered wallet address ${request.address}`, { ephemeral: true });
+        if (!commandContext.initiallyResponded) await commandContext.send(`<@${request.userDiscordId}>, registered wallet address ${request.address}`, { ephemeral: true });
 
     }
 }

--- a/src/app/commands/bounty/Wallet.ts
+++ b/src/app/commands/bounty/Wallet.ts
@@ -60,8 +60,8 @@ export default class Wallet extends SlashCommand {
             address: commandContext.options['eth-wallet-address'],
             commandContext: commandContext,
             buttonInteraction: null,
+            origRequest: null,
             callBack: null
-
         })
         //const { guildMember } = await DiscordUtils.getGuildAndMember(commandContext.guildID, commandContext.user.id);
 
@@ -70,21 +70,27 @@ export default class Wallet extends SlashCommand {
         }
         catch (e) {
             if (e instanceof ValidationError) {
+                console.log("Reply 11: commandContext.send");
                 await commandContext.send(`<@${commandContext.user.id}>\n` + e.message, { ephemeral: true });
                 return;
             } else if (e instanceof AuthorizationError) {
+                console.log("Reply 12: commandContext.send");
                 await commandContext.send(`<@${commandContext.user.id}>\n` + e.message, { ephemeral: true });
                 return;
             }
             else {
                 LogUtils.logError('error', e);
+                console.log("Reply 13: commandContext.send/delete");
                 await commandContext.send('Sorry something is not working and our devs are looking into it.', { ephemeral: true });
                 await commandContext.delete();
                 return;
             }
         }
 
-        if (!commandContext.initiallyResponded) await commandContext.send(`<@${request.userDiscordId}>, registered wallet address ${request.address}`, { ephemeral: true });
+        if (!commandContext.initiallyResponded) {
+            console.log("Reply 14: commandContext.send");
+            await commandContext.send(`<@${request.userDiscordId}>, registered wallet address ${request.address}`, { ephemeral: true });
+        }
 
     }
 }

--- a/src/app/commands/bounty/Wallet.ts
+++ b/src/app/commands/bounty/Wallet.ts
@@ -70,17 +70,14 @@ export default class Wallet extends SlashCommand {
         }
         catch (e) {
             if (e instanceof ValidationError) {
-                console.log("Reply 11: commandContext.send");
                 await commandContext.send(`<@${commandContext.user.id}>\n` + e.message, { ephemeral: true });
                 return;
             } else if (e instanceof AuthorizationError) {
-                console.log("Reply 12: commandContext.send");
                 await commandContext.send(`<@${commandContext.user.id}>\n` + e.message, { ephemeral: true });
                 return;
             }
             else {
                 LogUtils.logError('error', e);
-                console.log("Reply 13: commandContext.send/delete");
                 await commandContext.send('Sorry something is not working and our devs are looking into it.', { ephemeral: true });
                 await commandContext.delete();
                 return;
@@ -88,7 +85,6 @@ export default class Wallet extends SlashCommand {
         }
 
         if (!commandContext.initiallyResponded) {
-            console.log("Reply 14: commandContext.send");
             await commandContext.send(`<@${request.userDiscordId}>, registered wallet address ${request.address}`, { ephemeral: true });
         }
 

--- a/src/app/errors/ModalTimeoutError.ts
+++ b/src/app/errors/ModalTimeoutError.ts
@@ -1,0 +1,8 @@
+export default class ModalTimeoutError extends Error {
+
+	constructor(message: string) {
+		super(message);
+
+		Object.setPrototypeOf(this, ModalTimeoutError.prototype);
+	}
+}

--- a/src/app/events/InteractionCreate.ts
+++ b/src/app/events/InteractionCreate.ts
@@ -20,6 +20,7 @@ import NotificationPermissionError from '../errors/NotificationPermissionError';
 import DMPermissionError from '../errors/DMPermissionError';
 import ErrorUtils from '../utils/ErrorUtils';
 import { UpsertUserWalletRequest } from '../requests/UpsertUserWalletRequest';
+import ModalTimeoutError from '../errors/ModalTimeoutError';
 
 export default class implements DiscordEvent {
     name = 'interactionCreate';
@@ -258,7 +259,9 @@ export default class implements DiscordEvent {
                 Log.info(`${user.tag} submitted a request that failed validation`);
             } else if (e instanceof AuthorizationError) {
                 Log.info(`${user.tag} submitted a request that failed authorization`);
-            
+            } else if (e instanceof ModalTimeoutError) {
+                Log.info(`${user.tag} had a modal form timeout`);
+                errorContent = 'Form timeout. Please finish your entries within 1 minute.';
             } else if (e instanceof DMPermissionError) {
                 Log.info(`${user.tag} submitted a request that failed DM`);
                 errorContent = `It looks like bot does not have permission to DM <@${user.id}>.\n \n` +

--- a/src/app/requests/ApplyRequest.ts
+++ b/src/app/requests/ApplyRequest.ts
@@ -11,6 +11,7 @@ export class ApplyRequest extends Request {
     commandContext: CommandContext;
     message: Message;
     buttonInteraction: ButtonInteraction;
+    request: any;
 
     constructor(args: {
         commandContext: CommandContext,

--- a/src/app/requests/HelpRequest.ts
+++ b/src/app/requests/HelpRequest.ts
@@ -19,7 +19,7 @@ export class HelpRequest extends Request {
     }) {
         if (args.commandContext) {
             if (args.commandContext.subcommands[0] !== Activities.help) {
-                throw new Error('ListRequest created for non List activity.');
+                throw new Error('HelpRequest created for non List activity.');
             }
             super(args.commandContext.subcommands[0], args.commandContext.guildID, args.commandContext.user.id, args.commandContext.user.bot);
             this.commandContext = args.commandContext;

--- a/src/app/requests/ListRequest.ts
+++ b/src/app/requests/ListRequest.ts
@@ -17,11 +17,8 @@ export class ListRequest extends Request {
         buttonInteraction: ButtonInteraction,
     }) {
         if (args.commandContext) {
-            if (args.commandContext.subcommands[0] !== Activities.list) {
-                throw new Error('ListRequest created for non List activity.');
-            }
-            super(args.commandContext.subcommands[0], args.commandContext.guildID, args.commandContext.user.id, args.commandContext.user.bot);
-            this.listType = args.commandContext.options.list['list-type'];
+            super(Activities.list, args.commandContext.guildID, args.commandContext.user.id, args.commandContext.user.bot);
+            this.listType = args.commandContext.options?.list?.['list-type'];
             this.commandContext = args.commandContext;
         } else if (args.messageReactionRequest) {
             const messageReactionRequest: MessageReactionRequest = args.messageReactionRequest;

--- a/src/app/requests/UpsertUserWalletRequest.ts
+++ b/src/app/requests/UpsertUserWalletRequest.ts
@@ -1,21 +1,33 @@
+import { ButtonInteraction } from 'discord.js';
+import { CommandContext } from 'slash-create';
 import { Activities } from '../constants/activities';
 
 export class UpsertUserWalletRequest {
     userDiscordId: string;
     address: string;
     activity: string;
+    commandContext: CommandContext;
+    buttonInteraction: ButtonInteraction;
+    callBack: (request: UpsertUserWalletRequest) => any | null;
+
 
     constructor(args: {
         userDiscordId: string,
         address: string,
+        commandContext: CommandContext,
+        buttonInteraction: ButtonInteraction,
+        callBack: (request: UpsertUserWalletRequest) => any | null
     }) {
-        if (args.userDiscordId && args.address) {
+        if (args.userDiscordId) {
             this.userDiscordId = args.userDiscordId;
             this.address = args.address;
+            this.commandContext = args.commandContext;
+            this.buttonInteraction = args.buttonInteraction;
+            this.callBack = args.callBack;
             this.activity = Activities.registerWallet;
         }
         else {
-            throw new Error("userDiscordId and address must both be set");
+            throw new Error("userDiscordId must be set");
         }
     }
 }

--- a/src/app/requests/UpsertUserWalletRequest.ts
+++ b/src/app/requests/UpsertUserWalletRequest.ts
@@ -2,12 +2,15 @@ import { ButtonInteraction } from 'discord.js';
 import { CommandContext } from 'slash-create';
 import { Activities } from '../constants/activities';
 
+// origRequest and callBack are used if this is called as part of another activity request (e.g. Claim)
+
 export class UpsertUserWalletRequest {
     userDiscordId: string;
     address: string;
     activity: string;
     commandContext: CommandContext;
     buttonInteraction: ButtonInteraction;
+    origRequest: any;
     callBack: (request: UpsertUserWalletRequest) => any | null;
 
 
@@ -16,6 +19,7 @@ export class UpsertUserWalletRequest {
         address: string,
         commandContext: CommandContext,
         buttonInteraction: ButtonInteraction,
+        origRequest: any;
         callBack: (request: UpsertUserWalletRequest) => any | null
     }) {
         if (args.userDiscordId) {
@@ -23,6 +27,7 @@ export class UpsertUserWalletRequest {
             this.address = args.address;
             this.commandContext = args.commandContext;
             this.buttonInteraction = args.buttonInteraction;
+            this.origRequest = args.origRequest;
             this.callBack = args.callBack;
             this.activity = Activities.registerWallet;
         }

--- a/src/app/types/request/RequestCollection.ts
+++ b/src/app/types/request/RequestCollection.ts
@@ -1,6 +1,0 @@
-import { Collection, ObjectId } from 'mongodb';
-
-export interface RequestCollection extends Collection {
-	_id: ObjectId,
-    requestJSON: string,
-}

--- a/src/app/types/request/RequestCollection.ts
+++ b/src/app/types/request/RequestCollection.ts
@@ -1,0 +1,6 @@
+import { Collection, ObjectId } from 'mongodb';
+
+export interface RequestCollection extends Collection {
+	_id: ObjectId,
+    requestJSON: string,
+}

--- a/src/app/types/roles/CustomerRolesCollection.ts
+++ b/src/app/types/roles/CustomerRolesCollection.ts
@@ -1,4 +1,4 @@
-import { Snowflake } from 'discord-api-types';
+import { Snowflake } from 'discord-api-types/v9';
 import { Collection, ObjectId } from 'mongodb';
 
 export interface CustomerRolesCollection extends Collection {

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -15,7 +15,7 @@ import { CustomerCollection } from '../types/bounty/CustomerCollection';
 import { UpsertUserWalletRequest } from '../requests/UpsertUserWalletRequest';
 import { handler } from '../activity/bounty/Handler';
 import { UserCollection } from '../types/user/UserCollection';
-import { ModalInteractionContext, MessageOptions as scMessageOptions, Message as scMessage, ComponentType, TextInputStyle } from 'slash-create';
+import { ModalInteractionContext, MessageOptions as scMessageOptions, Message as scMessage, ComponentType, TextInputStyle, CommandContext } from 'slash-create';
 import WalletUtils from './WalletUtils';
 import RuntimeError from '../errors/RuntimeError';
 
@@ -280,7 +280,7 @@ const BountyUtils = {
 
     },
 
-    async canonicalCard(bountyId: string, activity: string, bountyChannel?: TextChannel, guildMember?: GuildMember, modalContext?: ModalInteractionContext): Promise<Message> {
+    async canonicalCard(bountyId: string, activity: string, bountyChannel?: TextChannel, guildMember?: GuildMember): Promise<Message> {
         Log.debug(`Creating/updating canonical card`);
 
         // Get the updated bounty

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -554,6 +554,7 @@ const BountyUtils = {
                     address: walletAddress,
                     commandContext: null,
                     buttonInteraction: null,
+                    origRequest: null,
                     callBack: null
                 })
 

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -263,19 +263,20 @@ const BountyUtils = {
             title += `\n(For role ${role.name})`;
         } else if (bountyRecord.isIOU) {
             title += `\n(IOU owed to ${bountyRecord.claimedBy.discordHandle})`;
-        } else {
-            if (bountyRecord.requireApplication) {
-                title += `\n(Requires application before claiming`;
-                if (bountyRecord.applicants) {
-                    if (bountyRecord.applicants.length == 1) {
-                        title += `. 1 applicant so far.`;
-                    } else {
-                        title += `. ${bountyRecord.applicants.length} applicants so far.`;
-                    }
+        } 
+
+        if (bountyRecord.requireApplication) {
+            title += `\n(Requires application before claiming`;
+            if (bountyRecord.applicants) {
+                if (bountyRecord.applicants.length == 1) {
+                    title += `. 1 applicant so far.`;
+                } else {
+                    title += `. ${bountyRecord.applicants.length} applicants so far.`;
                 }
-                title += ')'
             }
+            title += ')'
         }
+        
         return title;
 
     },

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -626,7 +626,8 @@ const BountyUtils = {
             const childBounty: BountyCollection = await bountyCollection.findOne({
             _id: new mongo.ObjectId(bounty.childrenIds[bounty.childrenIds.length -1])
              });
-             await this.fixBounty(childBounty);
+             const fixedChild = await this.fixBounty(childBounty);
+             await bountyCollection.replaceOne({ _id: new mongo.ObjectId(childBounty._id) }, fixedChild);
         }
     },
 

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -151,19 +151,19 @@ const DiscordUtils = {
         return messages.first();
     },
 
-    async interactionResponse(buttonInteraction: ButtonInteraction, content: string, link?: string) {
+    async interactionResponse(buttonInteraction: ButtonInteraction, content: string, link?: string, linkTitle?: string) {
         let replyOptions: MessageOptions = { content: content };
         if (link) {
             const componentActions = new MessageActionRow().addComponents(
                 new MessageButton()
-                    .setLabel('View Bounty')
+                    .setLabel(linkTitle ? linkTitle : 'View Bounty')
                     .setStyle('LINK')
                     .setURL(link || '')
             );
             replyOptions.components = [componentActions];
         } 
         try {
-            if ((buttonInteraction.deferred || buttonInteraction.replied)) await buttonInteraction.editReply(replyOptions);
+            if ((buttonInteraction.deferred || buttonInteraction.replied)) await buttonInteraction.followUp(Object.assign(replyOptions, { ephemeral: true }) as InteractionReplyOptions);
             else await buttonInteraction.reply(Object.assign(replyOptions, { ephemeral: true }) as InteractionReplyOptions);
         } catch (e) {
             if (e.code === 40060) await buttonInteraction.editReply(replyOptions);
@@ -185,7 +185,7 @@ const DiscordUtils = {
              }] : []) as ComponentActionRow[];
             await commandContext.send({ content: content, ephemeral: true, components: btnComponent });
         } else {// This was a button interaction
-            await this.interactionResponse(buttonInteraction, content, link);
+            await this.interactionResponse(buttonInteraction, content, link, linkTitle);
         }
     },
 
@@ -246,7 +246,7 @@ const DiscordUtils = {
                 commandContext: request.commandContext,
                 listType: undefined,
                 messageReactionRequest: {
-                    user: request.buttonInteraction.user,
+                    user: request.buttonInteraction?.user,
                     message: message
                 },
                 buttonInteraction: request.buttonInteraction,

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -172,14 +172,14 @@ const DiscordUtils = {
     },
 
     // Send a response to a command (use ephemeral) or a reaction (use DM)
-    async activityResponse(commandContext: CommandContext, buttonInteraction: ButtonInteraction, content: string, link?: string): Promise<void> {
+    async activityResponse(commandContext: CommandContext, buttonInteraction: ButtonInteraction, content: string, link?: string, linkTitle?: string): Promise<void> {
         if (!!commandContext) { // This was a slash command
             const btnComponent =  (link ? [{
 				type: ComponentType.ACTION_ROW,
 				components: [{
 					type: ComponentType.BUTTON,
 					style: ButtonStyle.LINK,
-                    label: 'View Bounty',
+                    label: linkTitle ? linkTitle : 'View Bounty',
                     url: link,
 				}]
              }] : []) as ComponentActionRow[];

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -1,4 +1,4 @@
-import { AwaitMessagesOptions, ButtonInteraction, Collection, DMChannel, Guild, GuildMember, Message, MessageActionRow, MessageButton, MessageOptions, Role, Snowflake, TextChannel } from 'discord.js';
+import { AwaitMessagesOptions, ButtonInteraction, Collection, DMChannel, Guild, GuildMember, InteractionReplyOptions, Message, MessageActionRow, MessageButton, MessageOptions, Role, Snowflake, TextChannel } from 'discord.js';
 import { Db } from 'mongodb';
 import { ButtonStyle, CommandContext, ComponentActionRow, ComponentContext, ComponentType } from 'slash-create';
 import { listBounty } from '../activity/bounty/List';
@@ -163,8 +163,8 @@ const DiscordUtils = {
             replyOptions.components = [componentActions];
         } 
         try {
-            if (buttonInteraction.deferred || buttonInteraction.replied) await buttonInteraction.editReply(replyOptions);
-            else await buttonInteraction.reply(Object.assign(replyOptions, { ephemeral: true }));
+            if ((buttonInteraction.deferred || buttonInteraction.replied)) await buttonInteraction.editReply(replyOptions);
+            else await buttonInteraction.reply(replyOptions as InteractionReplyOptions);
         } catch (e) {
             if (e.code === 40060) await buttonInteraction.editReply(replyOptions);
             else throw new RuntimeError(e);

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -171,7 +171,7 @@ const DiscordUtils = {
         }
     },
 
-    // Send a response to a command (use ephemeral) or a reaction (use DM)
+    // Send a response to a command (use ephemeral) or a reaction (use the context) or if neither, treat it as an activityNotification instead
     async activityResponse(commandContext: CommandContext, buttonInteraction: ButtonInteraction, content: string, link?: string, linkTitle?: string): Promise<void> {
         if (!!commandContext) { // This was a slash command
             const btnComponent =  (link ? [{
@@ -184,7 +184,7 @@ const DiscordUtils = {
 				}]
              }] : []) as ComponentActionRow[];
             await commandContext.send({ content: content, ephemeral: true, components: btnComponent });
-        } else {// This was a button interaction
+        } else { // This was a button interaction
             await this.interactionResponse(buttonInteraction, content, link, linkTitle);
         }
     },

--- a/src/app/utils/DiscordUtils.ts
+++ b/src/app/utils/DiscordUtils.ts
@@ -164,7 +164,7 @@ const DiscordUtils = {
         } 
         try {
             if ((buttonInteraction.deferred || buttonInteraction.replied)) await buttonInteraction.editReply(replyOptions);
-            else await buttonInteraction.reply(replyOptions as InteractionReplyOptions);
+            else await buttonInteraction.reply(Object.assign(replyOptions, { ephemeral: true }) as InteractionReplyOptions);
         } catch (e) {
             if (e.code === 40060) await buttonInteraction.editReply(replyOptions);
             else throw new RuntimeError(e);

--- a/src/app/utils/WalletUtils.ts
+++ b/src/app/utils/WalletUtils.ts
@@ -1,8 +1,11 @@
 import ValidationError from "../errors/ValidationError";
+
+export const ETHEREUM_WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/g;
+export const ADDRESS_DELETE_REGEX = /^DELETE$/ig;
+
 const WalletUtils = {
     validateEthereumWalletAddress(address: string): void {
-        const ETHEREUM_WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/g;
-        if (address == null || !ETHEREUM_WALLET_REGEX.test(address)) {
+        if (address == null || (!ETHEREUM_WALLET_REGEX.test(address) && !(ADDRESS_DELETE_REGEX.test(address)))) {
             throw new ValidationError(
                 'Invalid Ethereum Address. Format is "0x" followed by 40 hex characters.\n');
         }

--- a/src/app/utils/WalletUtils.ts
+++ b/src/app/utils/WalletUtils.ts
@@ -1,11 +1,13 @@
 import ValidationError from "../errors/ValidationError";
 
-export const ETHEREUM_WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/g;
-export const ADDRESS_DELETE_REGEX = /^DELETE$/ig;
+export const ETHEREUM_WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/;
+export const ADDRESS_DELETE_REGEX = /^DELETE$/i;
 
 const WalletUtils = {
     validateEthereumWalletAddress(address: string): void {
-        if (address == null || (!ETHEREUM_WALLET_REGEX.test(address) && !(ADDRESS_DELETE_REGEX.test(address)))) {
+        console.log(`Address in WalletUtis ${address} length ${address.length} regex ${ADDRESS_DELETE_REGEX.test(address)}`);
+        if (address == null || (!ETHEREUM_WALLET_REGEX.test(address) && (!ADDRESS_DELETE_REGEX.test(address)))) {
+            console.log("throwing wallet error");
             throw new ValidationError(
                 'Invalid Ethereum Address. Format is "0x" followed by 40 hex characters.\n');
         }

--- a/src/app/utils/WalletUtils.ts
+++ b/src/app/utils/WalletUtils.ts
@@ -5,9 +5,7 @@ export const ADDRESS_DELETE_REGEX = /^DELETE$/i;
 
 const WalletUtils = {
     validateEthereumWalletAddress(address: string): void {
-        console.log(`Address in WalletUtis ${address} length ${address.length} regex ${ADDRESS_DELETE_REGEX.test(address)}`);
         if (address == null || (!ETHEREUM_WALLET_REGEX.test(address) && (!ADDRESS_DELETE_REGEX.test(address)))) {
-            console.log("throwing wallet error");
             throw new ValidationError(
                 'Invalid Ethereum Address. Format is "0x" followed by 40 hex characters.\n');
         }

--- a/src/app/utils/WalletUtils.ts
+++ b/src/app/utils/WalletUtils.ts
@@ -4,7 +4,7 @@ const WalletUtils = {
         const ETHEREUM_WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/g;
         if (address == null || !ETHEREUM_WALLET_REGEX.test(address)) {
             throw new ValidationError(
-                'Please enter a valid ethereum address\n');
+                'Invalid Ethereum Address. Format is "0x" followed by 40 hex characters.\n');
         }
     } 
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
         "esModuleInterop": true,
         "noEmitOnError": true,
         "moduleResolution": "node",
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "skipLibCheck": true
     },
     "include": ["src/**/*.ts"],
     "exclude": ["node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,21 +2,21 @@
 # yarn lockfile v1
 
 
-"@discordjs/builders@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-0.11.0.tgz#4102abe3e0cd093501f3f71931df43eb92f5b0cc"
-  integrity sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==
+"@discordjs/builders@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-0.16.0.tgz#3201f57fa57c4dd77aebb480cf47da77b7ba2e8c"
+  integrity sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==
   dependencies:
-    "@sindresorhus/is" "^4.2.0"
-    discord-api-types "^0.26.0"
-    ts-mixer "^6.0.0"
-    tslib "^2.3.1"
-    zod "^3.11.6"
+    "@sapphire/shapeshift" "^3.5.1"
+    discord-api-types "^0.36.2"
+    fast-deep-equal "^3.1.3"
+    ts-mixer "^6.0.1"
+    tslib "^2.4.0"
 
-"@discordjs/collection@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.4.0.tgz#b6488286a1cc7b41b644d7e6086f25a1c1e6f837"
-  integrity sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw==
+"@discordjs/collection@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.7.0.tgz#1a6c00198b744ba2b73a64442145da637ac073b8"
+  integrity sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==
 
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"
@@ -84,20 +84,23 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@sapphire/async-queue@^1.1.9":
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.1.9.tgz#ce69611c8753c4affd905a7ef43061c7eb95c01b"
-  integrity sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ==
+"@sapphire/async-queue@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.5.0.tgz#2f255a3f186635c4fb5a2381e375d3dfbc5312d8"
+  integrity sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==
+
+"@sapphire/shapeshift@^3.5.1":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/shapeshift/-/shapeshift-3.6.0.tgz#988ff6576162a581a29bc26deb5492f7d1bf419f"
+  integrity sha512-tu2WLRdo5wotHRvsCkspg3qMiP6ETC3Q1dns1Q5V6zKUki+1itq6AbhMwohF9ZcLoYqg+Y8LkgRRtVxxTQVTBQ==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    lodash.uniqwith "^4.5.0"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
-
-"@sindresorhus/is@^4.2.0":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.2.1.tgz#b88b5724283db80b507cd612caee9a1947412a20"
-  integrity sha512-BrzrgtaqEre0qfvI8sMTaEvx+bayuhPmfe2rfeUGPPHYr/PLxCOqkOe4TQTDPb+qcqgNcsAtXV/Ew74mcDIE8w==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -126,10 +129,10 @@
     "@types/bson" "*"
     "@types/node" "*"
 
-"@types/node-fetch@^2.5.12":
-  version "2.5.12"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
-  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
+"@types/node-fetch@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
@@ -139,10 +142,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.8.tgz#50d680c8a8a78fe30abe6906453b21ad8ab0ad7b"
   integrity sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==
 
-"@types/ws@^8.2.2":
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.2.2.tgz#7c5be4decb19500ae6b3d563043cd407bf366c21"
-  integrity sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==
+"@types/ws@^8.5.3":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
+  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
   dependencies:
     "@types/node" "*"
 
@@ -608,25 +611,30 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-discord-api-types@^0.26.0:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.26.1.tgz#726f766ddc37d60da95740991d22cb6ef2ed787b"
-  integrity sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==
+discord-api-types@^0.33.3:
+  version "0.33.5"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.33.5.tgz#6548b70520f7b944c60984dca4ab58654d664a12"
+  integrity sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg==
 
-discord.js@^13.3.1:
-  version "13.6.0"
-  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-13.6.0.tgz#d8a8a591dbf25cbcf9c783d5ddf22c4694860475"
-  integrity sha512-tXNR8zgsEPxPBvGk3AQjJ9ljIIC6/LOPjzKwpwz8Y1Q2X66Vi3ZqFgRHYwnHKC0jC0F+l4LzxlhmOJsBZDNg9g==
+discord-api-types@^0.36.2:
+  version "0.36.3"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.36.3.tgz#a931b7e57473a5c971d6937fa5f392eb30047579"
+  integrity sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==
+
+discord.js@^13.7.1:
+  version "13.10.3"
+  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-13.10.3.tgz#c597d1aa5c06057ee55917251389ebc760cb997e"
+  integrity sha512-cIARuxfpQDeqA9Zw3fz4IL20xAhtMsjwJIf7/K82R3n2xROG9/fAx+7qjX8ysp9BfflYqMu2ZskyWq1EAmL5BA==
   dependencies:
-    "@discordjs/builders" "^0.11.0"
-    "@discordjs/collection" "^0.4.0"
-    "@sapphire/async-queue" "^1.1.9"
-    "@types/node-fetch" "^2.5.12"
-    "@types/ws" "^8.2.2"
-    discord-api-types "^0.26.0"
+    "@discordjs/builders" "^0.16.0"
+    "@discordjs/collection" "^0.7.0"
+    "@sapphire/async-queue" "^1.5.0"
+    "@types/node-fetch" "^2.6.2"
+    "@types/ws" "^8.5.3"
+    discord-api-types "^0.33.3"
     form-data "^4.0.0"
-    node-fetch "^2.6.1"
-    ws "^8.4.0"
+    node-fetch "^2.6.7"
+    ws "^8.8.1"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -1221,6 +1229,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.uniqwith@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz#7a0cbf65f43b5928625a9d4d0dc54b18cadc7ef3"
+  integrity sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==
+
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
@@ -1320,10 +1333,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-node-fetch@^2.6.1:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -1718,20 +1731,20 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-ts-mixer@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.0.tgz#4e631d3a36e3fa9521b973b132e8353bc7267f9f"
-  integrity sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ==
+ts-mixer@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.1.tgz#7c2627fb98047eb5f3c7f2fee39d1521d18fe87a"
+  integrity sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg==
 
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -1881,10 +1894,10 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^8.4.0:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.0.tgz#f05e982a0a88c604080e8581576e2a063802bed6"
-  integrity sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==
+ws@^8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
+  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"
@@ -1900,8 +1913,3 @@ yarn@^1.22.17:
   version "1.22.17"
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.17.tgz#bf910747d22497b573131f7341c0e1d15c74036c"
   integrity sha512-H0p241BXaH0UN9IeH//RT82tl5PfNraVpSpEoW+ET7lmopNC61eZ+A+IDvU8FM6Go5vx162SncDL8J1ZjRBriQ==
-
-zod@^3.11.6:
-  version "3.11.6"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.11.6.tgz#e43a5e0c213ae2e02aefe7cb2b1a6fa3d7f1f483"
-  integrity sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==


### PR DESCRIPTION
This implements modals for several operations on the bot.

First some things about Discord modals:

1) They only allow text input. No error checking, no selects, etc. Also only 5 text inputs allowed per modal.
2) Only one modal per interaction is allowed. If the user doesn't enter valid input, your only option is to tell the user and have them start over. One hack would be to save all input in the DB, keyed on userID, and repopulate when they try again. This PR does NOT do that.
3) There are two different modal handler patterns depending on whether it is initiated with a slash command or a button interaction. Slash uses the slash-create sendModal with a callback. Buttons use the discord.js showModal with an interaction collector and timeout. If a timeout occurs with the discord.js pattern (e.g. the user doesn't respond or hits Cancel), they will get a message about a form timeout. This might be confusing, but it shouldn't be a common thing.

Modals have been implemented in:
1) /bounty create for description, criteria, and due date
2) /bounty apply for the pitch entry
3) /register-wallet for the ETH address entry

There is no more draft/publish in the flow. Because of the the inability to delete/modify embeds on an ephemeral message from a previous interaction, I took it out. Otherwise drafts would show publicly.

Other changes/fixes:
1) /register-wallet now accepts DELETE to delete an address. It also responds with the address saved and a link to Etherscan so the user can second-check
2) If a user attempts a claim without a registered ETH address, they get the ETH address modal instead of a DM
3) If an IOU is created for a user who does not have a registered ETH address, they will get a DM with a button to invoke the /register-wallet command.
4) Modals require discord.js 13.7+, and in this case it we went to 13.10
5) The due date will default to 3 months out if blank. No more 'no' or 'skip'

