### PR TITLE
Add bCard currency

### DIFF
--- a/src/app/activity/bounty/Create.ts
+++ b/src/app/activity/bounty/Create.ts
@@ -97,9 +97,9 @@ export const modalCallback = async (modalContext: ModalInteractionContext, creat
 
     const dueAt = modalContext.values.dueAt;
     let convertedDueDateFromMessage: Date;
-    if (!dueAt){
+    if (!dueAt || (dueAt.toLowerCase() === 'no' || dueAt.toLowerCase() === 'skip')) {
         convertedDueDateFromMessage = BountyUtils.threeMonthsFromNow();
-    } else if (!(dueAt.toLowerCase() === 'no' || dueAt.toLowerCase() === 'skip')) {
+    } else {
         try {
             convertedDueDateFromMessage = BountyUtils.validateDate(dueAt);
         } catch (e) {

--- a/src/app/utils/BountyUtils.ts
+++ b/src/app/utils/BountyUtils.ts
@@ -78,7 +78,7 @@ const BountyUtils = {
 
     validateReward(rewardInput: string): void {
         const [stringAmount, symbol] = (rewardInput != null) ? rewardInput.split(' ') : [null, null];
-        const ALLOWED_CURRENCIES = ['BANK', 'ETH', 'BTC', 'USDC', 'USDT', 'TempCity', 'gOHM', 'LUSD', 'FOX', 'oneFOX', 'POINTS'];
+        const ALLOWED_CURRENCIES = ['BANK', 'ETH', 'BTC', 'USDC', 'USDT', 'BCARD'];
         const isValidCurrency = (typeof symbol !== 'undefined') && (ALLOWED_CURRENCIES.find(element => {
             return element.toLowerCase() === symbol.toLowerCase();
         }) !== undefined);


### PR DESCRIPTION
Added the Bankless Card currency (BCARD). It does not have a contract address, so it will not show up in Parcel.money exports, but will show up in the CSV and JSON exports.

Removed a bunch of unused currencies to match the list on the web.